### PR TITLE
feat: add Nvidia NIM endpoint support

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -262,6 +262,22 @@ impl Config {
             provider.api_base = Some(val);
         }
 
+        // vLLM
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VLLM_API_KEY") {
+            let provider = self
+                .providers
+                .vllm
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_key = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VLLM_API_BASE") {
+            let provider = self
+                .providers
+                .vllm
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_base = Some(val);
+        }
+
         // Ollama (local models)
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_OLLAMA_API_KEY") {
             let provider = self
@@ -274,6 +290,22 @@ impl Config {
             let provider = self
                 .providers
                 .ollama
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_base = Some(val);
+        }
+
+        // Nvidia NIM
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NVIDIA_API_KEY") {
+            let provider = self
+                .providers
+                .nvidia
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_key = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NVIDIA_API_BASE") {
+            let provider = self
+                .providers
+                .nvidia
                 .get_or_insert_with(ProviderConfig::default);
             provider.api_base = Some(val);
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -574,6 +574,8 @@ pub struct ProvidersConfig {
     pub gemini: Option<ProviderConfig>,
     /// Ollama (local models) configuration
     pub ollama: Option<ProviderConfig>,
+    /// Nvidia NIM configuration
+    pub nvidia: Option<ProviderConfig>,
     /// Retry behavior for runtime provider calls
     pub retry: RetryConfig,
     /// Fallback behavior across multiple configured runtime providers

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -39,6 +39,7 @@ pub const RUNTIME_SUPPORTED_PROVIDERS: &[&str] = &[
     "vllm",
     "gemini",
     "ollama",
+    "nvidia",
 ];
 
 use crate::error::ProviderError;

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -93,6 +93,13 @@ pub const PROVIDER_REGISTRY: &[ProviderSpec] = &[
         default_base_url: Some("http://localhost:11434/v1"),
         backend: "openai",
     },
+    ProviderSpec {
+        name: "nvidia",
+        model_keywords: &["nvidia", "nim"],
+        runtime_supported: true,
+        default_base_url: Some("https://integrate.api.nvidia.com/v1"),
+        backend: "openai",
+    },
 ];
 
 fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a ProviderConfig> {
@@ -105,6 +112,7 @@ fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a Pro
         "vllm" => config.providers.vllm.as_ref(),
         "gemini" => config.providers.gemini.as_ref(),
         "ollama" => config.providers.ollama.as_ref(),
+        "nvidia" => config.providers.nvidia.as_ref(),
         _ => None,
     }
 }
@@ -363,6 +371,23 @@ mod tests {
         assert_eq!(selected.name, "anthropic");
         assert_eq!(selected.backend, "anthropic");
         assert_eq!(selected.api_base, None);
+    }
+
+    #[test]
+    fn test_nvidia_resolves_with_default_base_url() {
+        let mut config = Config::default();
+        config.providers.nvidia = Some(ProviderConfig {
+            api_key: Some("nvapi-test".to_string()),
+            ..Default::default()
+        });
+
+        let selected = resolve_runtime_provider(&config).expect("provider should resolve");
+        assert_eq!(selected.name, "nvidia");
+        assert_eq!(selected.backend, "openai");
+        assert_eq!(
+            selected.api_base.as_deref(),
+            Some("https://integrate.api.nvidia.com/v1")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #30 — adds first-class Nvidia NIM endpoint support.

- Adds `nvidia` provider entry to the provider registry with default base URL `https://integrate.api.nvidia.com/v1`
- Uses the existing OpenAI-compatible backend (no new provider code needed)
- Adds env overrides: `ZEPTOCLAW_PROVIDERS_NVIDIA_API_KEY` and `ZEPTOCLAW_PROVIDERS_NVIDIA_API_BASE`
- Also adds **missing env overrides for vLLM** (`ZEPTOCLAW_PROVIDERS_VLLM_API_KEY`, `ZEPTOCLAW_PROVIDERS_VLLM_API_BASE`) which was the user's original setup path

### Usage

**Config file** (`~/.zeptoclaw/config.json`):
```json
{
  "providers": {
    "nvidia": {
      "api_key": "nvapi-your-key-here"
    }
  },
  "agents": {
    "defaults": {
      "model": "meta/llama-3.3-70b-instruct"
    }
  }
}
```

**Environment variables:**
```bash
export ZEPTOCLAW_PROVIDERS_NVIDIA_API_KEY="nvapi-your-key-here"
```

## Test plan

- [x] `cargo test --lib providers::registry` — 13 tests passing (1 new)
- [x] `cargo test --lib` — 1596 tests passing
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual: configure nvidia provider, run `zeptoclaw agent -m "hello"` with NIM model

🤖 Generated with [Claude Code](https://claude.com/claude-code)