### PR TITLE
feat(runtime): wire retry wrapper and preferred fallback ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@ Project-level guidance for coding agents working in this repository.
 - Channels: 5 (Telegram, Slack, Discord, Webhook, WhatsApp)
 - Skills: OpenClaw-compatible (reads `metadata.zeptoclaw` > `metadata.openclaw` > raw)
 - Plugins: Command-mode (shell template) + Binary-mode (JSON-RPC 2.0 stdin/stdout)
-- Runtime provider resolution: chains all configured runtime providers via `FallbackProvider` in registry order
+- Runtime provider resolution: builds chain in registry order only when `providers.fallback.enabled`; honors `providers.fallback.provider`; can wrap chain with `RetryProvider` via `providers.retry.*`
 - Channel dispatch: avoids holding the channels map `RwLock` across async `send()` awaits
-- Tests: 1566 lib + 50 main + 23 cli_smoke + 68 integration + 140 doc (116 passed, 24 ignored)
+- Tests: 1612 lib + 54 main + 23 cli_smoke + 68 integration + 140 doc (116 passed, 24 ignored)
 
 ## Post-Implementation Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ LLM provider abstraction via `LLMProvider` trait:
 - `RetryProvider` - Decorator: exponential backoff on 429/5xx with structured `ProviderError` classification
 - `FallbackProvider` - Decorator: primary → secondary auto-failover with circuit breaker (Closed/Open/HalfOpen)
 - `ProviderError` enum: Auth, RateLimit, Billing, ServerError, InvalidRequest, ModelNotFound, Timeout — enables smart retry/fallback
-- Runtime provider assembly in `create_agent()`: resolves all configured runtime providers (registry order) and builds a fallback chain (`p0 -> p1 -> p2 -> ...`)
+- Runtime provider assembly in `create_agent()`: resolves configured runtime providers in registry order, builds fallback chain only when `providers.fallback.enabled`, honors `providers.fallback.provider` as preferred first fallback, and optionally wraps the chain with `RetryProvider` (`providers.retry.*`)
 - `StreamEvent` enum + `chat_stream()` on LLMProvider trait for token-by-token streaming
 - `OutputFormat` enum (Text/Json/JsonSchema) with `to_openai_response_format()` and `to_claude_system_suffix()`
 
@@ -335,13 +335,19 @@ cargo build --release
 ## Testing
 
 ```bash
-# Unit tests (1314 tests)
+# Unit tests (1612 tests)
 cargo test --lib
+
+# Main binary tests (54 tests)
+cargo test --bin zeptoclaw
+
+# CLI smoke tests (23 tests)
+cargo test --test cli_smoke
 
 # Integration tests (68 tests)
 cargo test --test integration
 
-# All tests (~1,314 total including doc tests)
+# All tests (~1,900 total including doc tests)
 cargo test
 
 # Specific test

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -640,7 +640,7 @@ pub struct RetryConfig {
 impl Default for RetryConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             max_retries: 3,
             base_delay_ms: 1_000,
             max_delay_ms: 30_000,
@@ -649,22 +649,13 @@ impl Default for RetryConfig {
 }
 
 /// Fallback behavior across multiple configured runtime providers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct FallbackConfig {
     /// Enable provider fallback (primary -> secondary) when possible.
     pub enabled: bool,
     /// Optional preferred fallback provider id (e.g. "openai", "anthropic").
     pub provider: Option<String>,
-}
-
-impl Default for FallbackConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            provider: None,
-        }
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Context
PR #29 introduced the runtime fallback chain / channel lock-scope refactor / loop extraction, and was merged via #38.

This follow-up focuses on provider resiliency/config consistency gaps that still remained in runtime wiring:
- `providers.retry.*` existed but `RetryProvider` was not wired in `create_agent()`.
- `providers.fallback.provider` existed but was not used to influence fallback ordering.
- Retry/fallback behavior was not consistently opt-in at config default level.

## Changes

### 1) Wire retry config into runtime provider setup
- Added `apply_retry_wrapper()` in `src/cli/common.rs`.
- `create_agent()` now wraps resolved runtime provider chain with `RetryProvider` when `providers.retry.enabled = true`.
- Retry parameters are threaded from config:
  - `providers.retry.max_retries`
  - `providers.retry.base_delay_ms`
  - `providers.retry.max_delay_ms`

### 2) Honor preferred fallback provider
- Added `apply_fallback_preference()` in `src/cli/common.rs`.
- `build_runtime_provider_chain()` now supports `providers.fallback.provider` by moving the preferred configured provider to the first fallback slot after primary.
- Keeps primary provider selection in registry priority order.
- Keeps stable behavior when preferred fallback is missing/unsupported (warn + keep registry order).

### 3) Align defaults to opt-in resiliency
- Updated defaults in `src/config/types.rs`:
  - `RetryConfig.enabled = false`
  - `FallbackConfig.enabled = false`
- This keeps multi-provider fallback and retry behavior explicitly opt-in unless users enable them.

### 4) Documentation sync
- Updated provider behavior snapshots in:
  - `AGENTS.md`
  - `CLAUDE.md`
- Updated test count snapshots in docs to current values.

## Tests
Added/updated tests in `src/cli/common.rs`:
- `test_build_runtime_provider_chain_honors_preferred_fallback_provider`
- `test_apply_retry_wrapper_retries_when_enabled`
- `test_apply_retry_wrapper_is_noop_when_disabled`
- Updated multi-provider chain order test to explicitly enable fallback.

## Validation
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

Additional count checks:
- `cargo test --lib -- --list` => 1612
- `cargo test --bin zeptoclaw -- --list` => 54
- `cargo test --test cli_smoke -- --list` => 23
- `cargo test --test integration -- --list` => 68
- `cargo test --doc -- --list` => 140
