### PR TITLE
fix: code review fixes since v0.4.0

### DIFF
--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -127,11 +127,11 @@ impl MetricsCollector {
         self.session_start.elapsed()
     }
 
-    /// Compute an approximate p95 tool duration across all tools.
+    /// Compute the worst-case tool latency across all tools.
     ///
-    /// Uses `avg + 2 * (max - avg)` clamped to max as a rough estimate.
+    /// Uses `avg + 2 * (max - avg)` clamped to max as a rough upper-bound estimate.
     /// Returns `None` if no tool calls have been recorded.
-    pub fn approx_p95_duration(&self) -> Option<Duration> {
+    pub fn worst_case_tool_latency(&self) -> Option<Duration> {
         let tools = self.tools.lock().unwrap();
         let mut max_p95 = Duration::ZERO;
         let mut found_any = false;
@@ -399,18 +399,18 @@ mod tests {
     }
 
     #[test]
-    fn test_approx_p95_duration_no_calls() {
+    fn test_worst_case_tool_latency_no_calls() {
         let collector = MetricsCollector::new();
-        assert!(collector.approx_p95_duration().is_none());
+        assert!(collector.worst_case_tool_latency().is_none());
     }
 
     #[test]
-    fn test_approx_p95_duration_single_tool() {
+    fn test_worst_case_tool_latency_single_tool() {
         let collector = MetricsCollector::new();
         collector.record_tool_call("shell", Duration::from_millis(100), true);
         collector.record_tool_call("shell", Duration::from_millis(500), true);
 
-        let p95 = collector.approx_p95_duration().unwrap();
+        let p95 = collector.worst_case_tool_latency().unwrap();
         assert!(p95 >= Duration::from_millis(100));
         assert!(p95 <= Duration::from_millis(500));
     }

--- a/src/utils/slo.rs
+++ b/src/utils/slo.rs
@@ -38,7 +38,7 @@ impl SessionSLO {
     /// Evaluate SLOs from a completed session's metrics.
     pub fn evaluate(metrics: &MetricsCollector, agent_completed: bool) -> Self {
         let tool_success_rate = metrics.aggregate_success_rate();
-        let p95_latency = metrics.approx_p95_duration();
+        let p95_latency = metrics.worst_case_tool_latency();
         let p95_latency_met = match p95_latency {
             Some(d) => d.as_secs_f64() < SLO_P95_LATENCY_SECS,
             None => true,


### PR DESCRIPTION
## Summary
- **C1**: SLO emit now covers success, error, and timeout paths (was success-only)
- **C2**: Timezone label shows actual system UTC offset instead of config IANA name
- **I1**: Extracted `dry_run_result()` helper to deduplicate streaming/non-streaming dry-run code
- **I2**: Renamed `approx_p95_duration()` → `worst_case_tool_latency()` for clarity
- **I3**: Redacted tungstenite WebSocket errors to prevent bridge token leakage in logs
- **I5**: Added threshold validation (`0.0..=1.0`, finite) to `cleanup_expired()`

## Test plan
- [x] 1607 lib tests passing
- [x] clippy clean (`-D warnings`)
- [x] New test: `test_cleanup_expired_rejects_invalid_threshold`
- [x] Updated tests for timezone label and renamed metric method

🤖 Generated with [Claude Code](https://claude.com/claude-code)