### PR TITLE
fix: UTF-8 truncation panic and RISC-V getrandom SIGSEGV

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# RISC-V musl: use raw asm syscalls instead of libc::getrandom()
+# to avoid null-pointer SIGSEGV in release builds (GH-48).
+[target.riscv64gc-unknown-linux-musl]
+rustflags = ['--cfg', 'getrandom_backend="linux_raw"']

--- a/src/tools/custom.rs
+++ b/src/tools/custom.rs
@@ -164,7 +164,11 @@ impl Tool for CustomTool {
             let mut stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
             // Truncate oversized output to prevent blowing up the LLM context
             if stdout.len() > MAX_OUTPUT_BYTES {
-                stdout.truncate(MAX_OUTPUT_BYTES);
+                let mut end = MAX_OUTPUT_BYTES;
+                while !stdout.is_char_boundary(end) {
+                    end -= 1;
+                }
+                stdout.truncate(end);
                 stdout.push_str("\n... (output truncated)");
             }
             Ok(if stdout.is_empty() {

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -379,7 +379,12 @@ impl Tool for WebFetchTool {
 
         let truncated = text.len() > max_chars;
         if truncated {
-            text.truncate(max_chars);
+            // Find a valid UTF-8 char boundary at or before max_chars to avoid panic
+            let mut end = max_chars;
+            while !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            text.truncate(end);
         }
 
         Ok(json!({


### PR DESCRIPTION
## Summary

- **UTF-8 truncation panic** — `String::truncate()` panics when the byte offset lands inside a multi-byte character (emoji, CJK, accented chars). Fixed in `web.rs` and `custom.rs` by walking backwards to the nearest valid char boundary before truncating (matching the existing pattern in `compaction.rs` and `sanitize.rs`).
- **RISC-V SIGSEGV (#48)** — `getrandom` 0.4.1 uses `libc::getrandom()` on `riscv64gc-unknown-linux-musl`, but the musl weak symbol resolves to null in release builds causing a segfault in `Uuid::new_v4()`. Added `.cargo/config.toml` to force the `linux_raw` backend (raw `asm!` syscalls) for that target.

## Test plan

- [x] `cargo test --lib -- web::tests custom::tests` — 40/40 pass
- [x] `cargo check` — native build unaffected
- [ ] @kvark — please verify the RISC-V release build no longer segfaults on your MILK-V board

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)