### PR TITLE
fix: prevent UTF-8 truncation panic in web.rs and custom.rs

### DIFF
--- a/src/tools/custom.rs
+++ b/src/tools/custom.rs
@@ -164,7 +164,11 @@ impl Tool for CustomTool {
             let mut stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
             // Truncate oversized output to prevent blowing up the LLM context
             if stdout.len() > MAX_OUTPUT_BYTES {
-                stdout.truncate(MAX_OUTPUT_BYTES);
+                let mut end = MAX_OUTPUT_BYTES;
+                while !stdout.is_char_boundary(end) {
+                    end -= 1;
+                }
+                stdout.truncate(end);
                 stdout.push_str("\n... (output truncated)");
             }
             Ok(if stdout.is_empty() {

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -379,7 +379,12 @@ impl Tool for WebFetchTool {
 
         let truncated = text.len() > max_chars;
         if truncated {
-            text.truncate(max_chars);
+            // Find a valid UTF-8 char boundary at or before max_chars to avoid panic
+            let mut end = max_chars;
+            while !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            text.truncate(end);
         }
 
         Ok(json!({


### PR DESCRIPTION
## Summary

- `String::truncate()` panics when the byte offset falls inside a multi-byte UTF-8 character (emoji, CJK, accented chars)
- Fixed in `web.rs` and `custom.rs` by walking backwards to the nearest valid char boundary before truncating
- Matches the existing pattern already used in `compaction.rs` and `sanitize.rs`

Split from #51 — this PR contains only the UTF-8 fix; the RISC-V getrandom fix moves to a separate PR with a corrected approach.

Closes #49

## Test plan

- [x] `cargo test --lib -- web::tests custom::tests` — 40/40 pass
- [x] CI: clippy, fmt, test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)