### PR TITLE
chore(scripts): add local release build helpers

### DIFF
--- a/scripts/build-install-local.sh
+++ b/scripts/build-install-local.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Build and install a local ZeptoClaw release binary for command-line use.
+#
+# Usage:
+#   ./scripts/build-install-local.sh
+#   INSTALL_DIR="$HOME/.local/bin" ./scripts/build-install-local.sh
+#
+# Default install location:
+#   ~/.local/bin/zeptoclaw
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BINARY_PATH="${REPO_ROOT}/target/release/zeptoclaw"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+INSTALL_PATH="${INSTALL_DIR}/zeptoclaw"
+
+echo "Building local release from: ${REPO_ROOT}"
+cargo build --release --manifest-path "${REPO_ROOT}/Cargo.toml"
+
+if [ ! -x "${BINARY_PATH}" ]; then
+  echo "Error: build completed but binary not found at ${BINARY_PATH}"
+  exit 1
+fi
+
+mkdir -p "${INSTALL_DIR}"
+cp "${BINARY_PATH}" "${INSTALL_PATH}"
+chmod +x "${INSTALL_PATH}"
+
+echo ""
+echo "Installed: ${INSTALL_PATH}"
+"${INSTALL_PATH}" --version
+
+if ! command -v zeptoclaw >/dev/null 2>&1; then
+  echo ""
+  echo "Note: zeptoclaw is not currently on PATH for this shell."
+  echo "Add this to your shell profile:"
+  echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi

--- a/scripts/build-local-release.sh
+++ b/scripts/build-local-release.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Build a local ZeptoClaw release binary for testing current branch changes.
+#
+# Usage:
+#   ./scripts/build-local-release.sh
+#
+# Output:
+#   target/release/zeptoclaw
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BINARY_PATH="${REPO_ROOT}/target/release/zeptoclaw"
+
+echo "Building local release from: ${REPO_ROOT}"
+cargo build --release --manifest-path "${REPO_ROOT}/Cargo.toml"
+
+if [ ! -x "${BINARY_PATH}" ]; then
+  echo "Error: build completed but binary not found at ${BINARY_PATH}"
+  exit 1
+fi
+
+echo ""
+echo "Local release ready: ${BINARY_PATH}"
+echo "Version check:"
+"${BINARY_PATH}" --version


### PR DESCRIPTION
## Summary
- Add local release helper scripts:
  - `scripts/build-local-release.sh`
  - `scripts/build-install-local.sh`

## Why
These scripts standardize local release-build and install steps, reducing repeated manual commands and mistakes.

## Scope and Branch Hygiene
- Branched from `upstream/main`.
- This PR contains a single focused commit: `7034c7f`.
- Files changed:
  - `scripts/build-local-release.sh`
  - `scripts/build-install-local.sh`
- No unrelated sync or fork-maintenance commits included.

## Validation
Ran locally on this branch:
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

All passed.
