### PR TITLE
feat: channel delivery + cron scheduler resilience improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,10 @@ Project-level guidance for coding agents working in this repository.
 - Plugins: Command-mode (shell template) + Binary-mode (JSON-RPC 2.0 stdin/stdout)
 - Runtime provider resolution: builds chain in registry order only when `providers.fallback.enabled`; honors `providers.fallback.provider`; can wrap chain with `RetryProvider` via `providers.retry.*`
 - Channel dispatch: avoids holding the channels map `RwLock` across async `send()` awaits
-- Tests: 1719 lib + 54 main + 23 cli_smoke + 68 integration + 140 doc (116 passed, 24 ignored)
+- Telegram outbound formatting: sends HTML parse mode with `||spoiler||` → `<tg-spoiler>` conversion
+- Discord outbound delivery: supports reply references and thread-create metadata (`discord_thread_*`) in `OutboundMessage`
+- Cron scheduling hardening: dispatch timeout + exponential error backoff + one-shot delete-after-run only on success
+- Tests: 1791 lib + 59 main + 23 cli_smoke + 13 e2e + 68 integration + 141 doc (116 passed, 25 ignored)
 
 ## Task Tracking Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,9 @@ src/
 ├── channels/       # Input channels (Telegram, Slack, WhatsApp, etc.)
 │   ├── factory.rs  # Channel factory/registry
 │   ├── manager.rs  # Channel lifecycle management
-│   ├── telegram.rs # Telegram bot channel
+│   ├── telegram.rs # Telegram bot channel (HTML parse mode + ||spoiler|| support)
 │   ├── slack.rs    # Slack outbound channel
-│   ├── discord.rs  # Discord Gateway WebSocket + REST
+│   ├── discord.rs  # Discord Gateway WebSocket + REST (reply + thread create)
 │   ├── webhook.rs  # Generic HTTP webhook inbound
 │   ├── whatsapp.rs # WhatsApp via whatsmeow-rs bridge (WebSocket)
 │   └── whatsapp_cloud.rs # WhatsApp Cloud API (official webhook + REST)
@@ -148,7 +148,7 @@ src/
 │   ├── tools.rs    # Tool discovery list/info + dynamic status summary
 │   └── watch.rs    # URL change monitoring with channel notification
 ├── config/         # Configuration types and loading
-├── cron/           # Persistent cron scheduler service
+├── cron/           # Persistent cron scheduler service (dispatch timeout + error backoff)
 ├── deps/           # Dependency manager (install, start, stop, health check)
 │   ├── types.rs    # Dependency, DepKind, HealthCheck, HasDependencies
 │   ├── registry.rs # JSON registry (installed state tracking)
@@ -180,7 +180,7 @@ src/
 │   ├── web.rs         # Web search (Brave) and fetch with SSRF protection
 │   ├── whatsapp.rs    # WhatsApp Cloud API messaging
 │   ├── gsheets.rs     # Google Sheets read/write
-│   ├── message.rs     # Proactive channel messaging
+│   ├── message.rs     # Proactive channel messaging (reply/thread hints)
 │   ├── memory.rs      # Workspace memory get/search
 │   ├── longterm_memory.rs # Long-term memory tool (set/get/search/delete/list/categories/pin)
 │   ├── cron.rs        # Cron job scheduling
@@ -241,7 +241,7 @@ OAuth support with PKCE, CSRF state validation, encrypted token persistence, and
 Message input channels via `Channel` trait:
 - `TelegramChannel` - Telegram bot integration
 - `SlackChannel` - Slack outbound messaging
-- `DiscordChannel` - Discord Gateway WebSocket + REST API messaging
+- `DiscordChannel` - Discord Gateway WebSocket + REST API messaging (replies + thread creation)
 - `WebhookChannel` - Generic HTTP POST inbound with optional Bearer auth
 - `WhatsAppChannel` - WhatsApp via whatsmeow-rs bridge (WebSocket JSON protocol)
 - `WhatsAppCloudChannel` - WhatsApp Cloud API (webhook inbound + REST outbound, no bridge)
@@ -411,19 +411,22 @@ cargo build --release
 ## Testing
 
 ```bash
-# Unit tests (1719 tests)
+# Unit tests (1791 tests)
 cargo test --lib
 
-# Main binary tests (54 tests)
+# Main binary tests (59 tests)
 cargo test --bin zeptoclaw
 
 # CLI smoke tests (23 tests)
 cargo test --test cli_smoke
 
+# End-to-end tests (13 tests)
+cargo test --test e2e
+
 # Integration tests (68 tests)
 cargo test --test integration
 
-# All tests (~2,004 total including doc tests)
+# All tests (~2,101 total including doc tests)
 cargo test
 
 # Specific test

--- a/src/channels/plugin.rs
+++ b/src/channels/plugin.rs
@@ -833,7 +833,10 @@ mod tests {
         .unwrap();
 
         let plugins = discover_channel_plugins(dir.path());
-        assert!(plugins.is_empty(), "path traversal binary should be rejected");
+        assert!(
+            plugins.is_empty(),
+            "path traversal binary should be rejected"
+        );
     }
 
     // ---- Debug formatting ----


### PR DESCRIPTION
## Summary

Channel delivery and cron scheduler resilience improvements.

## Changes

- Telegram outbound formatting:
  - Send with HTML parse mode
  - Convert `||spoiler||` markers to `<tg-spoiler>...</tg-spoiler>`
- Discord outbound delivery:
  - Add support for reply references via outbound message fields
  - Add thread creation support using `discord_thread_*` metadata hints
- Message bus + message tool:
  - Add outbound metadata support
  - Add `reply_to` and `discord_thread_*` tool parameters (while preserving existing action modes)
- Cron scheduler hardening:
  - Dispatch timeout protection
  - Exponential error backoff
  - Consecutive error + run duration tracking
  - One-shot delete-after-run only after successful execution

## Docs
- Updated `CLAUDE.md`
- Updated `AGENTS.md`

## Validation
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`