### PR TITLE
docs: add provider configuration guide for all 9 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ $ zeptoclaw agent --stream -m "Analyze our API for security issues"
 ✓ Analysis complete in 4.2s
 ```
 
-We studied the best AI assistants — and their tradeoffs. OpenClaw's integrations without the 100MB. NanoClaw's security without the TypeScript bundle. PicoClaw's size without the bare-bones feature set. One Rust binary with 17 tools, 5 channels, 8 providers, and container isolation.
+We studied the best AI assistants — and their tradeoffs. OpenClaw's integrations without the 100MB. NanoClaw's security without the TypeScript bundle. PicoClaw's size without the bare-bones feature set. One Rust binary with 17 tools, 5 channels, 9 providers, and container isolation.
 
 <p align="center">
   <img src="https://img.shields.io/badge/binary-~4MB-3b82f6" alt="~4MB binary">
   <img src="https://img.shields.io/badge/startup-~50ms-3b82f6" alt="~50ms startup">
   <img src="https://img.shields.io/badge/RAM-~6MB-3b82f6" alt="~6MB RAM">
   <img src="https://img.shields.io/badge/tests-1%2C300%2B-3b82f6" alt="1,300+ tests">
-  <img src="https://img.shields.io/badge/providers-8-3b82f6" alt="8 providers">
+  <img src="https://img.shields.io/badge/providers-9-3b82f6" alt="9 providers">
 </p>
 
 ## Why ZeptoClaw
@@ -151,7 +151,41 @@ Supports JSON and JSON5 config files (comments, trailing commas, unquoted keys).
 curl -fsSL https://zeptoclaw.com/setup.sh | bash
 ```
 
-Interactive setup guides you through provider keys and channel selection. Installs the binary, creates a systemd service, starts on boot.
+Installs the binary and prints next steps. Run `zeptoclaw onboard` to configure providers and channels.
+
+## Providers
+
+ZeptoClaw supports 9 LLM providers. All OpenAI-compatible endpoints work out of the box.
+
+| Provider | Config key | Setup |
+|----------|------------|-------|
+| **Anthropic** | `anthropic` | `api_key` |
+| **OpenAI** | `openai` | `api_key` |
+| **OpenRouter** | `openrouter` | `api_key` |
+| **Groq** | `groq` | `api_key` |
+| **Ollama** | `ollama` | `api_key` (any value) |
+| **VLLM** | `vllm` | `api_key` (any value) |
+| **Google Gemini** | `gemini` | `api_key` |
+| **NVIDIA NIM** | `nvidia` | `api_key` |
+| **Zhipu (GLM)** | `zhipu` | `api_key` |
+
+Configure in `~/.zeptoclaw/config.json` or via environment variables:
+
+```json
+{
+  "providers": {
+    "openrouter": { "api_key": "sk-or-..." },
+    "ollama": { "api_key": "ollama" }
+  },
+  "agents": { "defaults": { "model": "anthropic/claude-sonnet-4" } }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_GROQ_API_KEY=gsk_...
+```
+
+Any provider's base URL can be overridden with `api_base` for proxies or self-hosted endpoints. See the [provider docs](https://zeptoclaw.com/docs/concepts/providers/) for full details.
 
 ## Features
 
@@ -159,7 +193,7 @@ Interactive setup guides you through provider keys and channel selection. Instal
 
 | Feature | What it does |
 |---------|-------------|
-| **Multi-Provider LLM** | Claude + OpenAI with SSE streaming, retry with backoff, auto-failover |
+| **Multi-Provider LLM** | 9 providers with SSE streaming, retry with backoff, auto-failover |
 | **17 Tools + Plugins** | Shell, filesystem, web, memory, cron, WhatsApp, Google Sheets, and more |
 | **Agent Swarms** | Delegate to sub-agents with role-specific prompts and tool whitelists |
 | **Batch Mode** | Process hundreds of prompts from text/JSONL files with template support |

--- a/landing/zeptoclaw/docs/src/content/docs/concepts/providers.md
+++ b/landing/zeptoclaw/docs/src/content/docs/concepts/providers.md
@@ -3,21 +3,251 @@ title: Providers
 description: LLM providers and the resilient provider stack
 ---
 
-Providers are the LLM backends that power your agent. ZeptoClaw supports multiple providers with automatic retry and failover.
+Providers are the LLM backends that power your agent. ZeptoClaw supports 9 providers out of the box, all configurable via `~/.zeptoclaw/config.json` or environment variables.
 
 ## Supported providers
 
-| Provider | Models | Streaming |
-|----------|--------|-----------|
-| **Claude** (Anthropic) | Claude Sonnet 4.5, Opus 4, etc. | SSE |
-| **OpenAI** | GPT-5.1, GPT-4o, etc. | SSE |
+| Provider | Backend | Default model | Notes |
+|----------|---------|---------------|-------|
+| **Anthropic** | Native | claude-sonnet-4-5 | Claude API |
+| **OpenAI** | Native | gpt-5.1 | OpenAI API |
+| **OpenRouter** | OpenAI-compatible | — | 400+ models via single key |
+| **Groq** | OpenAI-compatible | — | Fast inference |
+| **Ollama** | OpenAI-compatible | — | Local models |
+| **VLLM** | OpenAI-compatible | — | Local model serving |
+| **Google Gemini** | OpenAI-compatible | — | Gemini models |
+| **NVIDIA NIM** | OpenAI-compatible | — | NVIDIA inference |
+| **Zhipu (GLM)** | OpenAI-compatible | — | Chinese LLM |
+
+All providers except Anthropic use the OpenAI-compatible chat completions API, so any endpoint that speaks that protocol works.
+
+## Quick setup
+
+The fastest way to configure a provider:
+
+```bash
+zeptoclaw onboard
+```
+
+The onboard wizard supports Anthropic, OpenAI, and OpenRouter. For other providers, edit `~/.zeptoclaw/config.json` directly or use environment variables.
+
+## Configuration
+
+### Anthropic
+
+```json
+{
+  "providers": {
+    "anthropic": {
+      "api_key": "sk-ant-..."
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### OpenAI
+
+```json
+{
+  "providers": {
+    "openai": {
+      "api_key": "sk-..."
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_OPENAI_API_KEY=sk-...
+```
+
+### OpenRouter
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "api_key": "sk-or-..."
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "anthropic/claude-sonnet-4"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_OPENROUTER_API_KEY=sk-or-...
+```
+
+The default base URL is `https://openrouter.ai/api/v1`. Set `model` to any model available on OpenRouter.
+
+### Groq
+
+```json
+{
+  "providers": {
+    "groq": {
+      "api_key": "gsk_..."
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "mixtral-8x7b-32768"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_GROQ_API_KEY=gsk_...
+```
+
+### Ollama
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "api_key": "ollama"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "mistral"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_OLLAMA_API_KEY=ollama
+```
+
+The default base URL is `http://localhost:11434/v1`. The API key value doesn't matter (Ollama doesn't require one) but the field must be set.
+
+To connect to a remote Ollama instance:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "api_key": "ollama",
+      "api_base": "http://my-server:11434/v1"
+    }
+  }
+}
+```
+
+### VLLM
+
+```json
+{
+  "providers": {
+    "vllm": {
+      "api_key": "vllm"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "meta-llama/Llama-2-7b-hf"
+    }
+  }
+}
+```
+
+The default base URL is `http://localhost:8000/v1`.
+
+### Google Gemini
+
+```json
+{
+  "providers": {
+    "gemini": {
+      "api_key": "AIza..."
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "gemini-2.5-pro"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_GEMINI_API_KEY=AIza...
+```
+
+### NVIDIA NIM
+
+```json
+{
+  "providers": {
+    "nvidia": {
+      "api_key": "nvapi-..."
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "meta/llama-3.1-8b-instruct"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_NVIDIA_API_KEY=nvapi-...
+```
+
+### Zhipu (GLM)
+
+```json
+{
+  "providers": {
+    "zhipu": {
+      "api_key": "..."
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "glm-4"
+    }
+  }
+}
+```
+
+## Custom API base URL
+
+Any provider's base URL can be overridden. This is useful for proxies, self-hosted endpoints, or alternative API gateways:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "api_key": "sk-...",
+      "api_base": "https://my-proxy.example.com/v1"
+    }
+  }
+}
+```
+
+```bash
+export ZEPTOCLAW_PROVIDERS_OPENAI_API_BASE=https://my-proxy.example.com/v1
+```
 
 ## Provider stack
 
 ZeptoClaw wraps providers in a composable stack:
 
 ```
-Base Provider (Claude or OpenAI)
+Base Provider
     │
     ▼
 ┌───────────────────┐
@@ -33,27 +263,7 @@ Base Provider (Claude or OpenAI)
       Agent Loop
 ```
 
-## Configuration
-
-Set your provider in `~/.zeptoclaw/config.json`:
-
-```json
-{
-  "providers": {
-    "default": "anthropic",
-    "anthropic": {
-      "api_key": "sk-ant-...",
-      "model": "claude-sonnet-4-5-20250929"
-    },
-    "openai": {
-      "api_key": "sk-...",
-      "model": "gpt-5.1"
-    }
-  }
-}
-```
-
-## Retry provider
+### Retry
 
 Automatically retries on transient failures (HTTP 429 rate limits and 5xx server errors):
 
@@ -70,16 +280,17 @@ Automatically retries on transient failures (HTTP 429 rate limits and 5xx server
 }
 ```
 
-Uses exponential backoff: delay doubles after each retry, capped at `max_delay_ms`.
+Delay doubles after each retry, capped at `max_delay_ms`.
 
-## Fallback provider
+### Fallback
 
 Automatically switches to a backup provider when the primary fails:
 
 ```json
 {
   "providers": {
-    "default": "anthropic",
+    "anthropic": { "api_key": "sk-ant-..." },
+    "openai": { "api_key": "sk-..." },
     "fallback": {
       "enabled": true,
       "provider": "openai"
@@ -88,35 +299,45 @@ Automatically switches to a backup provider when the primary fails:
 }
 ```
 
-If Claude returns an error, ZeptoClaw automatically retries with OpenAI.
+The fallback provider uses a circuit breaker: after 3 consecutive failures the primary is bypassed, and after a 30-second cooldown it's probed again.
 
 ## Streaming
 
-Both providers support SSE streaming for real-time token delivery:
+All providers support SSE streaming:
 
 ```bash
 zeptoclaw agent --stream -m "Tell me a story"
 ```
 
-The `StreamEvent` enum carries individual tokens, tool calls, and completion signals. Streaming works in CLI mode, gateway mode, and batch mode.
+## Environment variables
 
-## Structured output
-
-Control the response format with the `output_format` option:
-
-- **Text** — Default free-form text
-- **Json** — Requests JSON output from the model
-- **JsonSchema** — Enforces a specific JSON schema (OpenAI `response_format`)
-
-## Cost tracking
-
-ZeptoClaw tracks token usage and estimates costs per model. Pricing tables cover 8 models across both providers. View costs in metrics output or Prometheus export.
-
-## Compile-time defaults
-
-Override default models at build time:
+Every provider field can be set via environment variables:
 
 ```bash
-export ZEPTOCLAW_DEFAULT_MODEL=gpt-5.1
-cargo build --release
+# API keys
+ZEPTOCLAW_PROVIDERS_ANTHROPIC_API_KEY=...
+ZEPTOCLAW_PROVIDERS_OPENAI_API_KEY=...
+ZEPTOCLAW_PROVIDERS_OPENROUTER_API_KEY=...
+ZEPTOCLAW_PROVIDERS_GROQ_API_KEY=...
+ZEPTOCLAW_PROVIDERS_OLLAMA_API_KEY=...
+ZEPTOCLAW_PROVIDERS_VLLM_API_KEY=...
+ZEPTOCLAW_PROVIDERS_GEMINI_API_KEY=...
+ZEPTOCLAW_PROVIDERS_NVIDIA_API_KEY=...
+ZEPTOCLAW_PROVIDERS_ZHIPU_API_KEY=...
+
+# Custom base URLs
+ZEPTOCLAW_PROVIDERS_OPENAI_API_BASE=...
+ZEPTOCLAW_PROVIDERS_OLLAMA_API_BASE=...
+
+# Retry
+ZEPTOCLAW_PROVIDERS_RETRY_ENABLED=true
+ZEPTOCLAW_PROVIDERS_RETRY_MAX_RETRIES=3
+ZEPTOCLAW_PROVIDERS_RETRY_BASE_DELAY_MS=1000
+ZEPTOCLAW_PROVIDERS_RETRY_MAX_DELAY_MS=30000
+
+# Fallback
+ZEPTOCLAW_PROVIDERS_FALLBACK_ENABLED=true
+ZEPTOCLAW_PROVIDERS_FALLBACK_PROVIDER=openai
 ```
+
+Environment variables take precedence over config.json values.


### PR DESCRIPTION
## Summary
- Rewrite `concepts/providers.md` with config examples for all 9 supported providers (was only Anthropic + OpenAI)
- Add Providers section to README with quick-reference table, config example, and env var example
- Fix "8 providers" → "9 providers" in badge and description
- Update VPS setup blurb to reflect simplified setup.sh

## Test plan
- [ ] Docs site builds with `npx astro build`
- [ ] Provider config examples match actual config struct fields