### PR TITLE
feat(auth): Claude Code subscription token support

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -13,6 +13,10 @@ pub mod store;
 
 use serde::{Deserialize, Serialize};
 
+/// Claude Code's OAuth client ID, used when importing subscription tokens
+/// obtained via `claude auth token`.
+pub const CLAUDE_CODE_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
 // ============================================================================
 // Auth Method
 // ============================================================================

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -262,6 +262,8 @@ pub enum AuthAction {
         /// Provider to refresh tokens for
         provider: String,
     },
+    /// Set up a Claude Code subscription token for API access
+    SetupToken,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## Summary
- Add `zeptoclaw auth setup-token` command for importing OAuth tokens from Claude Code CLI (`claude auth token`)
- Add subscription token option to `zeptoclaw onboard` Anthropic setup (choice 2)
- Add `CLAUDE_CODE_CLIENT_ID` constant for token storage

Closes #88

## Test plan
- [ ] `cargo fmt && cargo clippy -- -D warnings && cargo test --lib` passes (1896 tests)
- [ ] `zeptoclaw auth setup-token` prompts for access/refresh tokens and stores them encrypted
- [ ] `zeptoclaw onboard` offers subscription token as option 2 for Anthropic
- [ ] `zeptoclaw auth status` shows the stored OAuth token after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)