### PR TITLE
fix: remove broken interactive prompts from setup.sh

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -311,10 +311,10 @@ main() {
   printf "\n${BOLD}=== Installation Complete ===${RESET}\n\n"
 
   if [ "$MODE" = "docker" ]; then
-    VERSION="$(docker run --rm "$DOCKER_IMAGE" zeptoclaw --version 2>/dev/null || echo 'installed')"
+    VERSION="$(docker inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' "$DOCKER_IMAGE" 2>/dev/null || echo 'latest')"
     ok "ZeptoClaw ${VERSION}"
     printf "\n${BOLD}Next step:${RESET}\n"
-    printf "  docker run --rm -it -v %s:/data %s zeptoclaw onboard\n\n" "$CONFIG_DIR" "$DOCKER_IMAGE"
+    printf "  docker run --rm -it -v %s:/data/.zeptoclaw %s zeptoclaw onboard\n\n" "$CONFIG_DIR" "$DOCKER_IMAGE"
   else
     VERSION="$(${INSTALL_DIR}/${BINARY} --version 2>/dev/null || echo 'installed')"
     ok "ZeptoClaw ${VERSION}"


### PR DESCRIPTION
Picks up #86 (thanks @montanaflynn) and adds a Docker mount fix found during review.

## Changes

- Remove `prompt_value()`, `prompt_secret()`, `config_wizard()`, `write_config_json()`, `write_deploy_env()`, `create_systemd_service()`, `start_docker_container()`, `verify_install()` — all interactive steps that break `curl | sh`
- After install: print "Next step: run `zeptoclaw onboard`" for binary mode, `docker run ... zeptoclaw onboard` for Docker mode
- Delete duplicate `landing/zeptoclaw/setup.sh`, update `landing/deploy.sh` reference

## Docker mount fix (added on top of #86)

The onboard guidance command had a volume mount bug:

```sh
# Before (wrong)
docker run --rm -it -v ~/.zeptoclaw:/data $IMAGE zeptoclaw onboard

# After (correct)
docker run --rm -it -v ~/.zeptoclaw:/data/.zeptoclaw $IMAGE zeptoclaw onboard
```

Container user home is `/data` (set in Dockerfile via `useradd -d /data`). ZeptoClaw resolves config via `dirs::home_dir().join(".zeptoclaw")` → `/data/.zeptoclaw`. The old mount mapped `~/.zeptoclaw` to `/data`, so config writes landed at `~/.zeptoclaw/.zeptoclaw` on the host — silently discarded when `--rm` container exited.

Also replaces `docker run --rm $IMAGE zeptoclaw --version` (full container startup just for a version string) with `docker inspect` label lookup.

Closes #85
Supersedes #86