### PR TITLE
fix: exclude benchmark binary from cargo install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/qhkm/zeptoclaw"
 homepage = "https://github.com/qhkm/zeptoclaw"
 keywords = ["ai", "agent", "llm", "cli", "rust"]
 categories = ["command-line-utilities"]
+autobins = false
 
 [dependencies]
 # =============================================================================


### PR DESCRIPTION
## Summary
- Set `autobins = false` in `[package]` so only the explicit `[[bin]]` target (`zeptoclaw`) is installed
- Previously `src/bin/benchmark.rs` was auto-discovered and installed as an extra binary during `cargo install`

## Test plan
- [x] `cargo metadata` confirms only `zeptoclaw` bin target
- [x] `cargo test --lib` — 2403 passed
- [x] `cargo clippy -- -D warnings` — 0 warnings

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)