### PR TITLE
fix: handle full GitHub URLs in skills install

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -292,7 +292,7 @@ pub enum SkillsAction {
     Install {
         /// ClawHub slug (reserved for future use)
         slug: Option<String>,
-        /// Install from GitHub repository (owner/repo format)
+        /// Install from GitHub repository (owner/repo or full URL)
         #[arg(long)]
         github: Option<String>,
     },


### PR DESCRIPTION
## Summary

- Fix `skills install --github` failing with `Skill '' already exists` when given a full GitHub URL (e.g. `https://github.com/owner/repo`) instead of `owner/repo` shorthand
- Strip `.git` suffix from URLs to avoid creating directories named `repo.git`
- Reject sub-path URLs (`owner/repo/tree/main`) and path traversal attempts (`owner/..`) with clear error messages
- Surface git stderr on clone failures instead of a generic error

## Test plan

- [x] `cargo test test_normalize_github_repo` — 8 test cases pass
- [x] Manual: `skills install --github https://github.com/ClawPocket/zeptoclaw-skill` installs successfully
- [x] Manual: sub-path URLs, path traversal, `.git` suffix, no-slash inputs all produce correct errors
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)