### PR TITLE
fix(doctor): false negative on binary detection in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ FROM debian:bookworm-slim AS runtime
 # Install minimal runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    git \
     gosu \
     wget \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

- **Root cause**: `check_binary()` used `which` to detect binaries, but `which` is absent in minimal Docker images (Debian slim), causing false negatives where git was installed but reported as missing
- **Fix**: Probe binaries directly with `<name> --version` instead of relying on `which`
- **Removed spurious `curl` check** — ZeptoClaw uses `reqwest` for HTTP, never shells out to curl
- **Added actionable hints** to warnings (e.g., "git not found — skill installation from GitHub won't work")
- **Dockerfile**: Added `git` to runtime image so skill installation works out of the box

## Test plan

- [ ] `cargo fmt && cargo clippy -- -D warnings && cargo test --lib && cargo fmt -- --check`
- [ ] `zeptoclaw doctor` reports `[ok] git found` when git is installed
- [ ] `zeptoclaw doctor` no longer checks for curl
- [ ] Docker image includes git in runtime stage

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)