### PR TITLE
docs: sync README, CLAUDE.md, CHANGELOG, and landing page with codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ZeptoClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-02-26
+
+### Fixed
+- RPi I2C block read/write method names corrected for rppal API (`block_read`/`block_write`)
+
+### Changed
+- Dependency upgrades: teloxide 0.12→0.17, tokio-tungstenite 0.21→0.28
+
+## [0.5.9] - 2026-02-26
+
+### Added
+- **ZeptoAgent facade improvements** — Sequential execution, callback support, and repair semantics for embedding as a crate (#157)
+
+### Fixed
+- Upgrade teloxide 0.12→0.17 and tokio-tungstenite 0.21→0.28 for compatibility (#156)
+
 ## [0.5.8] - 2026-02-25
 
 ### Added
@@ -173,6 +189,8 @@ First public release.
 - Mount allowlist validation
 - Cron job caps and spawn recursion prevention
 
+[0.6.0]: https://github.com/qhkm/zeptoclaw/releases/tag/v0.6.0
+[0.5.9]: https://github.com/qhkm/zeptoclaw/releases/tag/v0.5.9
 [0.5.8]: https://github.com/qhkm/zeptoclaw/releases/tag/v0.5.8
 [0.5.0]: https://github.com/qhkm/zeptoclaw/releases/tag/v0.5.0
 [0.4.0]: https://github.com/qhkm/zeptoclaw/releases/tag/v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Use conventional commits:
 1. Create `src/tools/yourtool.rs`
 2. Implement the `Tool` trait with `async fn execute()`
 3. Register in `src/tools/mod.rs` and `src/lib.rs`
-4. Register in agent setup in `src/cli/agent.rs`
+4. Register in agent setup in `src/cli/common.rs`
 5. Add tests
 
 ## Adding a New Channel

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ cargo clippy -- -D warnings
 cargo fmt -- --check
 ```
 
-See [CLAUDE.md](CLAUDE.md) for full architecture reference and [AGENTS.md](AGENTS.md) for coding guidelines.
+See [CLAUDE.md](CLAUDE.md) for full architecture reference, [AGENTS.md](AGENTS.md) for coding guidelines, and [docs/](docs/) for benchmarks, multi-tenant deployment, and performance guides.
 
 ## Contributing
 

--- a/landing/zeptoclaw/index.html
+++ b/landing/zeptoclaw/index.html
@@ -18,13 +18,13 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://zeptoclaw.com/">
     <meta property="og:title" content="ZeptoClaw — A Complete AI Agent Runtime in 4MB">
-    <meta property="og:description" content="17 tools, 5 channels, container isolation, agent swarms — one Rust binary. The smallest, fastest, safest member of the Claw family.">
+    <meta property="og:description" content="29 tools, 9 channels, container isolation, agent swarms — one Rust binary. The smallest, fastest, safest member of the Claw family.">
     <meta property="og:image" content="https://zeptoclaw.com/og-image.png">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ZeptoClaw — A Complete AI Agent Runtime in 4MB">
-    <meta name="twitter:description" content="17 tools, 5 channels, container isolation, agent swarms — one Rust binary. The smallest, fastest, safest member of the Claw family.">
+    <meta name="twitter:description" content="29 tools, 9 channels, container isolation, agent swarms — one Rust binary. The smallest, fastest, safest member of the Claw family.">
     <meta name="twitter:image" content="https://zeptoclaw.com/og-image.png">
 
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -1350,9 +1350,9 @@
                     <div class="family-lang">Rust</div>
                     <p>The one that took notes. Security, integrations, and minimalism — without the tradeoffs.</p>
                     <ul class="family-traits">
-                        <li>~4MB binary, 1,300+ tests</li>
-                        <li>17 tools + plugin system</li>
-                        <li>5 channels + agent swarms</li>
+                        <li>~4MB binary, 2,880+ tests</li>
+                        <li>29 tools + plugin system</li>
+                        <li>9 channels + agent swarms</li>
                         <li>Container isolation</li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Summary
- Add missing v0.5.9 and v0.6.0 entries to CHANGELOG.md
- Fix CONTRIBUTING.md tool registration path (`src/cli/agent.rs` → `src/cli/common.rs`)
- Update landing page OG/Twitter meta tags and body from "17 tools, 5 channels" to "29 tools, 9 channels"
- Add 13 missing tools, 2 missing channels, and 3 missing modules to CLAUDE.md architecture tree
- Fix tool count from "18" to "29 built-in" in CLAUDE.md (2 locations)
- Add `google` and `memory-bm25` features to Cargo Features section, deduplicate duplicate section
- Link `docs/` directory from README.md

## Test plan
- [ ] Verify CHANGELOG.md version links resolve correctly
- [ ] Verify landing page meta tags render correctly with social card validators
- [ ] Verify CONTRIBUTING.md path matches actual file location
- [ ] Verify all tools listed in CLAUDE.md architecture tree exist as files in `src/tools/`

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lark/Feishu and Email messaging channels
  * Introduced agent modes (Observer, Assistant, Autonomous)
  * Expanded built-in tool library to 29 tools
  * Added configuration-driven hooks and migration utilities

* **Changed**
  * Dependency upgrades

* **Bug Fixes**
  * Corrected Raspberry Pi I2C block read/write behavior reported in changelog

* **Documentation**
  * Updated release notes, README links, contributing instructions, and landing page feature text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->