### PR TITLE
fix: per-skill install from multi-skill repos

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -288,11 +288,11 @@ pub enum SkillsAction {
         #[arg(long, default_value = "all")]
         source: String,
     },
-    /// Install a skill from GitHub
+    /// Install a skill by name (from community repo) or --github
     Install {
-        /// ClawHub slug (reserved for future use)
-        slug: Option<String>,
-        /// Install from GitHub repository (owner/repo or full URL)
+        /// Skill name (installs from community repo by default)
+        name: String,
+        /// Install from explicit GitHub repo (owner/repo or owner/repo/skill)
         #[arg(long)]
         github: Option<String>,
     },


### PR DESCRIPTION
## Summary

- `zeptoclaw skills install obsidian-vault` now works — installs from default community repo (`qhkm/zeptoclaw-skills`)
- `--github owner/repo/skill-path` installs a single skill from a multi-skill repo
- `--github owner/repo` still works for single-skill repos
- `validate_skill_name()` blocks path traversal (`..`, `/`, `\`, `.hidden`)
- Fixes security issue: bulk install of all skills from multi-skill repos

## Before/After

| Before | After |
|--------|-------|
| `skills install --github qhkm/zeptoclaw-skills` (installs ALL 15 skills) | `skills install obsidian-vault` (installs just one) |
| No community repo default | Default community repo built in |
| `slug` arg unused | `name` arg required, drives install |

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` zero warnings
- [x] 2590 lib tests passing
- [x] 7 CLI tests passing (validate_skill_name, github_segment_parsing, copy_dir_recursive, community_repo_constant, normalize_github_repo + existing)
- [ ] Manual: `zeptoclaw skills install obsidian-vault` from community repo
- [ ] Manual: `zeptoclaw skills install weather --github qhkm/zeptoclaw-skills/weather`

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill installation now supports installing by name from a community repository as the default option.
  * Added support for installing from multi-skill GitHub repositories via path specification.

* **Bug Fixes**
  * Enhanced input validation for skill names to ensure filesystem safety and prevent invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->