### PR TITLE
docs: sync stats and feature tables for v0.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Project-level guidance for coding agents working in this repository.
 - Session repair: auto-fixes orphan tool results, empty/duplicate messages, alternation issues
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
-- Tests: 2609 lib + 97 main + 23 cli_smoke + 13 e2e + 70 integration + 122 doc (27 ignored)
+- Tests: 2609 lib + 97 main + 23 cli_smoke + 13 e2e + 70 integration + 122 doc (33 ignored)
 
 ## Task Tracking Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.6.0] - 2026-02-26
 
+### Added
+- **Loop guard** — SHA256 tool-call repetition detection with configurable window and threshold; warns then circuit-breaks on repeated patterns (#171)
+- **Emergency context trimming** — Three-tier compaction (normal 70% / emergency 90% / critical 95%) with reduced tool result budgets at higher tiers (#172)
+- **Session repair** — Auto-fixes orphan tool results, empty/duplicate messages, and role alternation issues before sending to LLM (#173)
+- **Config hot-reload** — Gateway polls config file mtime every 30s; applies provider, channel, and safety changes without restart (#174)
+- **Hands-lite** — `HAND.toml` agent profiles with bundled presets (researcher, coder, monitor); `hand list/activate/deactivate/status` CLI commands (#176)
+- **Telegram forum topic support** — Messages in forum topics include `thread_id` for thread-aware replies (#170)
+
 ### Fixed
 - RPi I2C block read/write method names corrected for rppal API (`block_read`/`block_write`)
+- Tool result budget now uses configured `max_tool_result_bytes` instead of hardcoded 5120 in emergency compaction (#177)
 
 ### Changed
 - Dependency upgrades: teloxide 0.12→0.17, tokio-tungstenite 0.21→0.28
+- Test count increased from 2,880+ to 2,900+
 
 ## [0.5.9] - 2026-02-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cargo clippy -- -D warnings
 cargo fmt
 
 # Test counts (cargo test)
-# lib: 2609, main: 97, cli_smoke: 23, e2e: 13, integration: 70, doc: 122 passed (27 ignored)
+# lib: 2609, main: 97, cli_smoke: 23, e2e: 13, integration: 70, doc: 122 passed (33 ignored)
 
 # Version
 ./target/release/zeptoclaw --version
@@ -565,10 +565,10 @@ cargo build --release
 ## Testing
 
 ```bash
-# Unit tests (2590 tests)
+# Unit tests (2609 tests)
 cargo test --lib
 
-# Main binary tests (91 tests)
+# Main binary tests (97 tests)
 cargo test --bin zeptoclaw
 
 # CLI smoke tests (23 tests)
@@ -580,7 +580,7 @@ cargo test --test e2e
 # Integration tests (70 tests)
 cargo test --test integration
 
-# All tests (~2,748 total including doc tests)
+# All tests (~2,935 total including doc tests)
 cargo test
 
 # Specific test

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We studied the best AI assistants — and their tradeoffs. OpenClaw's integratio
   <img src="https://img.shields.io/badge/binary-~6MB-3b82f6" alt="~6MB binary">
   <img src="https://img.shields.io/badge/startup-~50ms-3b82f6" alt="~50ms startup">
   <img src="https://img.shields.io/badge/RAM-~6MB-3b82f6" alt="~6MB RAM">
-  <img src="https://img.shields.io/badge/tests-2%2C880%2B-3b82f6" alt="2,880+ tests">
+  <img src="https://img.shields.io/badge/tests-2%2C900%2B-3b82f6" alt="2,900+ tests">
   <img src="https://img.shields.io/badge/providers-9-3b82f6" alt="9 providers">
 </p>
 
@@ -227,6 +227,11 @@ Any provider's base URL can be overridden with `api_base` for proxies or self-ho
 | **Rich Health Endpoint** | `/health` with version, uptime, RSS, usage metrics, component checks |
 | **Telemetry** | Prometheus + JSON metrics export, structured logging, per-tenant tracing |
 | **Self-Update** | `zeptoclaw update` downloads latest release from GitHub |
+| **Loop Guard** | SHA256 tool-call repetition detection with circuit-breaker stop |
+| **Context Trimming** | Normal/emergency/critical compaction tiers (70%/90%/95%) for context window management |
+| **Session Repair** | Auto-fixes orphan tool results, empty/duplicate messages, and alternation issues |
+| **Config Hot-Reload** | Gateway polls config mtime every 30s and applies provider/channel/safety updates live |
+| **Hands-Lite** | `HAND.toml` agent profiles with bundled presets (researcher, coder, monitor) and `hand` CLI |
 | **Multi-Tenant** | Hundreds of tenants on one VPS — isolated workspaces, ~6MB RAM each |
 
 > **Full documentation** — [zeptoclaw.com/docs](https://zeptoclaw.com/docs/) covers configuration, environment variables, CLI reference, deployment guides, and more.
@@ -265,6 +270,12 @@ zeptoclaw update
 
 # Encrypt secrets in config
 zeptoclaw secrets encrypt
+
+# Manage agent hands (profiles)
+zeptoclaw hand list
+zeptoclaw hand activate researcher
+zeptoclaw hand deactivate
+zeptoclaw hand status
 ```
 
 ## Development
@@ -273,7 +284,7 @@ zeptoclaw secrets encrypt
 # Build
 cargo build
 
-# Run all tests (~2,880 total)
+# Run all tests (~2,900 total)
 cargo test
 
 # Lint and format (required before every PR)

--- a/landing/zeptoclaw/index.html
+++ b/landing/zeptoclaw/index.html
@@ -1168,10 +1168,10 @@
                     Then we built one binary that gets it all right.
                 </p>
                 <div class="hero-stats">
-                    <div class="hero-stat">⚡ <span>~4MB</span> binary</div>
-                    <div class="hero-stat">🔌 <span>8</span> providers</div>
-                    <div class="hero-stat">📡 <span>5</span> channels</div>
-                    <div class="hero-stat">🧪 <span>1,300+</span> tests</div>
+                    <div class="hero-stat">⚡ <span>~6MB</span> binary</div>
+                    <div class="hero-stat">🔌 <span>9</span> providers</div>
+                    <div class="hero-stat">📡 <span>9</span> channels</div>
+                    <div class="hero-stat">🧪 <span>2,900+</span> tests</div>
                 </div>
                 <div class="hero-cta">
                     <a href="#install" class="btn btn-primary">Install ZeptoClaw</a>
@@ -1279,7 +1279,7 @@
                 <div class="feature-card">
                     <div class="feature-icon">🦀</div>
                     <h3>Written in Rust</h3>
-                    <p>Memory safety without garbage collection. 1000+ tests. Async-first with Tokio. Minimal resource usage even under heavy load.</p>
+                    <p>Memory safety without garbage collection. 2,900+ tests. Async-first with Tokio. Minimal resource usage even under heavy load.</p>
                 </div>
             </div>
         </div>
@@ -1350,7 +1350,7 @@
                     <div class="family-lang">Rust</div>
                     <p>The one that took notes. Security, integrations, and minimalism — without the tradeoffs.</p>
                     <ul class="family-traits">
-                        <li>~4MB binary, 2,880+ tests</li>
+                        <li>~6MB binary, 2,900+ tests</li>
                         <li>29 tools + plugin system</li>
                         <li>9 channels + agent swarms</li>
                         <li>Container isolation</li>
@@ -1444,19 +1444,19 @@
     <section class="stats">
         <div class="stats-grid">
             <div class="stat-item">
-                <div class="stat-value" data-count="4" data-prefix="~" data-suffix="MB">~4MB</div>
+                <div class="stat-value" data-count="6" data-prefix="~" data-suffix="MB">~6MB</div>
                 <div class="stat-label">Release Binary</div>
             </div>
             <div class="stat-item">
-                <div class="stat-value" data-count="20" data-suffix="+">20+</div>
-                <div class="stat-label">Core Modules</div>
-            </div>
-            <div class="stat-item">
-                <div class="stat-value" data-count="17">17</div>
+                <div class="stat-value" data-count="29" data-suffix="+">29+</div>
                 <div class="stat-label">Tools + Plugins</div>
             </div>
             <div class="stat-item">
-                <div class="stat-value" data-count="1300" data-suffix="+">1300+</div>
+                <div class="stat-value" data-count="9">9</div>
+                <div class="stat-label">Channels</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-value" data-count="2900" data-suffix="+">2900+</div>
                 <div class="stat-label">Tests Passing</div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Update test count badges and stats from 2,880+ to 2,900+ (actual: 2,935 total)
- Add 6 new features to README Security & Ops table: Loop Guard, Context Trimming, Session Repair, Config Hot-Reload, Hands-Lite
- Add CHANGELOG entries for all openfang-inspired features (#170-#177)
- Fix stale CLAUDE.md test counts (2590→2609 lib, 91→97 main, 2748→2935 total)
- Fix stale landing page stats: binary 4MB→6MB, providers 8→9, channels 5→9, tools 17→29, tests 1300→2900
- Add `hand` CLI usage examples to README

## Test plan
- [x] Verified actual test counts: `cargo test` → 2935 total (2609 lib + 97 main + 23 cli_smoke + 13 e2e + 70 integration + 1 benchmark + 122 doc)
- [ ] Visual check landing page stats render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Loop Guard for tool-call repetition detection
  * Added emergency context trimming with three-tier compaction thresholds
  * Added session repair for auto-fixing messaging issues
  * Added configuration hot-reload capability
  * Added Hands-Lite agent profiles with CLI support
  * Added Telegram forum topic context support
  * Added new agent management commands

* **Documentation**
  * Updated test counts and statistics across documentation
  * Updated landing page with new metrics and feature descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->