### PR TITLE
security: add SSRF guardrails to skill installer downloads

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1796,6 +1796,13 @@ pub struct ClawHubConfig {
     /// Optional Bearer token for authenticated registry access.
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// Hostnames explicitly allowed to bypass SSRF checks.
+    ///
+    /// Use this for self-hosted skill registries on private networks
+    /// (e.g., `["registry.internal.corp"]`). Public registries like
+    /// `clawhub.ai` do not need to be listed here.
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
 }
 
 fn default_clawhub_url() -> String {
@@ -1808,6 +1815,7 @@ impl Default for ClawHubConfig {
             enabled: true,
             base_url: default_clawhub_url(),
             auth_token: None,
+            allowed_hosts: Vec::new(),
         }
     }
 }

--- a/src/kernel/registrar.rs
+++ b/src/kernel/registrar.rs
@@ -489,10 +489,11 @@ pub async fn register_all_tools(
             config.tools.skills.search_cache.max_size,
             Duration::from_secs(config.tools.skills.search_cache.ttl_seconds),
         ));
-        let clawhub = Arc::new(ClawHubRegistry::new(
+        let clawhub = Arc::new(ClawHubRegistry::with_allowed_hosts(
             &config.tools.skills.clawhub.base_url,
             config.tools.skills.clawhub.auth_token.clone(),
             cache,
+            config.tools.skills.clawhub.allowed_hosts.clone(),
         ));
         if filter.is_enabled("find_skills") {
             registry.register(Box::new(crate::tools::FindSkillsTool::new(Arc::clone(

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -1,10 +1,18 @@
 //! ClawHub skill registry client with in-memory search cache.
+//!
+//! All outbound HTTP requests are guarded against SSRF attacks by reusing the
+//! same `is_blocked_host` / `resolve_and_check_host` checks that protect
+//! `web_fetch`. Self-hosted registries on private networks can opt in via
+//! `ClawHubConfig::allowed_hosts`.
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use reqwest::Url;
+
+use crate::tools::web::{is_blocked_host, resolve_and_check_host};
 
 /// A single skill entry returned from a ClawHub search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,12 +131,59 @@ fn validate_slug(slug: &str) -> crate::error::Result<()> {
     Ok(())
 }
 
+/// Validate that a URL does not target a private/local/link-local address.
+///
+/// If the URL's host is in `allowed_hosts`, the check is skipped (opt-in
+/// override for self-hosted registries on private networks).
+async fn check_ssrf(url_str: &str, allowed_hosts: &[String]) -> crate::error::Result<()> {
+    let parsed = Url::parse(url_str).map_err(|e| {
+        crate::error::ZeptoError::SecurityViolation(format!("Invalid URL '{}': {}", url_str, e))
+    })?;
+
+    // Only allow http/https schemes.
+    match parsed.scheme() {
+        "http" | "https" => {}
+        _ => {
+            return Err(crate::error::ZeptoError::SecurityViolation(
+                "Only http/https URLs are allowed for skill downloads".to_string(),
+            ));
+        }
+    }
+
+    // If the host is explicitly allowed, skip SSRF checks.
+    if let Some(host) = parsed.host_str() {
+        let host_lower = host.to_ascii_lowercase();
+        if allowed_hosts
+            .iter()
+            .any(|ah| ah.to_ascii_lowercase() == host_lower)
+        {
+            return Ok(());
+        }
+    }
+
+    // Hostname / IP blocklist (localhost, private ranges, link-local, etc.)
+    if is_blocked_host(&parsed) {
+        return Err(crate::error::ZeptoError::SecurityViolation(format!(
+            "Skill URL targets a blocked host (local or private network): {}",
+            url_str
+        )));
+    }
+
+    // DNS resolution check — catches hostnames that resolve to private IPs
+    // (e.g., `metadata.attacker.com` → 169.254.169.254).
+    resolve_and_check_host(&parsed).await?;
+
+    Ok(())
+}
+
 /// HTTP client for the ClawHub REST API.
 pub struct ClawHubRegistry {
     base_url: String,
     auth_token: Option<String>,
     client: reqwest::Client,
     cache: Arc<SearchCache>,
+    /// Hostnames allowed to bypass SSRF checks (for self-hosted registries).
+    allowed_hosts: Vec<String>,
 }
 
 impl ClawHubRegistry {
@@ -146,6 +201,29 @@ impl ClawHubRegistry {
                 .build()
                 .expect("reqwest client"),
             cache,
+            allowed_hosts: Vec::new(),
+        }
+    }
+
+    /// Create a new registry client with an explicit SSRF-bypass allowlist.
+    ///
+    /// Hosts in `allowed_hosts` are exempt from the private/local IP check,
+    /// enabling self-hosted registries on internal networks.
+    pub fn with_allowed_hosts(
+        base_url: impl Into<String>,
+        auth_token: Option<String>,
+        cache: Arc<SearchCache>,
+        allowed_hosts: Vec<String>,
+    ) -> Self {
+        Self {
+            base_url: base_url.into(),
+            auth_token,
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("reqwest client"),
+            cache,
+            allowed_hosts,
         }
     }
 
@@ -170,6 +248,10 @@ impl ClawHubRegistry {
             percent_encode(query),
             limit
         );
+
+        // SSRF guard: validate the URL before making the request.
+        check_ssrf(&url, &self.allowed_hosts).await?;
+
         let mut req = self.client.get(&url);
         if let Some(token) = &self.auth_token {
             req = req.bearer_auth(token);
@@ -208,6 +290,10 @@ impl ClawHubRegistry {
         validate_slug(slug)?;
 
         let url = format!("{}/api/v1/download/{}", self.base_url, slug);
+
+        // SSRF guard: validate the URL before making the request.
+        check_ssrf(&url, &self.allowed_hosts).await?;
+
         let mut req = self.client.get(&url);
         if let Some(token) = &self.auth_token {
             req = req.bearer_auth(token);
@@ -217,6 +303,27 @@ impl ClawHubRegistry {
             .send()
             .await
             .map_err(|e| crate::error::ZeptoError::Tool(e.to_string()))?;
+
+        // SSRF redirect check: validate the final destination after redirects.
+        if is_blocked_host(resp.url()) {
+            if let Some(host) = resp.url().host_str() {
+                let host_lower = host.to_ascii_lowercase();
+                let is_allowed = self
+                    .allowed_hosts
+                    .iter()
+                    .any(|ah| ah.to_ascii_lowercase() == host_lower);
+                if !is_allowed {
+                    return Err(crate::error::ZeptoError::SecurityViolation(format!(
+                        "Skill download redirected to blocked host: {}",
+                        resp.url()
+                    )));
+                }
+            } else {
+                return Err(crate::error::ZeptoError::SecurityViolation(
+                    "Skill download redirected to URL with no host".to_string(),
+                ));
+            }
+        }
 
         if !resp.status().is_success() {
             return Err(crate::error::ZeptoError::Tool(format!(
@@ -457,5 +564,136 @@ mod tests {
         assert!(validate_slug("skill;rm -rf").is_err());
         assert!(validate_slug("skill<script>").is_err());
         assert!(validate_slug("skill%20encoded").is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // SSRF guardrails (check_ssrf)
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_localhost() {
+        let result = check_ssrf("http://localhost:8080/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "localhost should be blocked");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("blocked") || err.contains("private") || err.contains("local"),
+            "Error should mention blocking: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_private_ipv4() {
+        let result = check_ssrf("http://192.168.1.1/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "192.168.x.x should be blocked");
+
+        let result = check_ssrf("http://10.0.0.5/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "10.x.x.x should be blocked");
+
+        let result = check_ssrf("http://172.16.0.1/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "172.16.x.x should be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_loopback() {
+        let result = check_ssrf("http://127.0.0.1:9090/download", &[]).await;
+        assert!(result.is_err(), "127.0.0.1 should be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_link_local_metadata() {
+        // AWS/GCP/Azure metadata endpoint
+        let result = check_ssrf("http://169.254.169.254/latest/meta-data/", &[]).await;
+        assert!(
+            result.is_err(),
+            "Cloud metadata endpoint should be blocked"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_allows_public_url() {
+        // Public URLs should pass SSRF checks
+        let result = check_ssrf("https://clawhub.ai/api/v1/download/web-scraper", &[]).await;
+        assert!(result.is_ok(), "Public URL should be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_allowed_hosts_bypass() {
+        // A private IP that is explicitly allowed should pass
+        let allowed = vec!["192.168.1.100".to_string()];
+        let result =
+            check_ssrf("http://192.168.1.100/api/v1/download/test", &allowed).await;
+        assert!(
+            result.is_ok(),
+            "Explicitly allowed host should bypass SSRF checks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_allowed_hosts_case_insensitive() {
+        let allowed = vec!["Registry.Internal.Corp".to_string()];
+        let result = check_ssrf(
+            "https://registry.internal.corp/api/v1/download/test",
+            &allowed,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "Allowed host matching should be case-insensitive"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_rejects_ftp_scheme() {
+        let result = check_ssrf("ftp://example.com/skill.tar.gz", &[]).await;
+        assert!(result.is_err(), "ftp:// should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("http/https"),
+            "Error should mention scheme restriction: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_rejects_file_scheme() {
+        let result = check_ssrf("file:///etc/passwd", &[]).await;
+        assert!(result.is_err(), "file:// should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_ipv6_loopback() {
+        let result = check_ssrf("http://[::1]:8080/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "IPv6 loopback should be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_check_ssrf_blocks_unspecified() {
+        let result = check_ssrf("http://0.0.0.0/api/v1/download/test", &[]).await;
+        assert!(result.is_err(), "0.0.0.0 should be blocked");
+    }
+
+    // -------------------------------------------------------------------------
+    // ClawHubRegistry with allowed_hosts
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_registry_new_has_empty_allowed_hosts() {
+        let cache = Arc::new(SearchCache::new(10, Duration::from_secs(60)));
+        let registry = ClawHubRegistry::new("https://clawhub.ai", None, cache);
+        assert!(registry.allowed_hosts.is_empty());
+    }
+
+    #[test]
+    fn test_registry_with_allowed_hosts_stores_list() {
+        let cache = Arc::new(SearchCache::new(10, Duration::from_secs(60)));
+        let hosts = vec!["internal.corp".to_string(), "10.0.0.5".to_string()];
+        let registry = ClawHubRegistry::with_allowed_hosts(
+            "http://10.0.0.5",
+            None,
+            cache,
+            hosts.clone(),
+        );
+        assert_eq!(registry.allowed_hosts, hosts);
     }
 }


### PR DESCRIPTION
## Summary

Reuse the existing `is_blocked_host()` and `resolve_and_check_host()` SSRF protection from `web_fetch` to guard all outbound HTTP requests made by the ClawHub skill registry client (search + download endpoints).

## Problem

The skill installer (`ClawHubRegistry::search()` and `download_and_install()`) makes outbound HTTP requests using a user-configurable `base_url` without any SSRF validation. An attacker who controls the registry URL (or can manipulate DNS) could:

- Probe internal services via `http://localhost:*` or `http://192.168.x.x`
- Access cloud metadata endpoints (`http://169.254.169.254`)
- Exfiltrate data through DNS rebinding attacks

Meanwhile, `web_fetch` already has production-grade SSRF protection that covers all these attack vectors.

## Changes

### Core fix: `src/skills/registry.rs`
- Added `check_ssrf()` helper that validates URLs against the same private/local/link-local IP blocklist used by `web_fetch`
- Guarded both `ClawHubRegistry::search()` and `download_and_install()` with pre-request SSRF validation
- Added post-redirect SSRF check on download responses to catch `302→internal` redirects
- Added `allowed_hosts` field to `ClawHubRegistry` for self-hosted registries that legitimately need private network access

### Config: `src/config/types.rs`
- Added `allowed_hosts: Vec<String>` to `ClawHubConfig` for opt-in SSRF bypass

### Wiring: `src/cli/common.rs`
- Updated registry construction to pass `allowed_hosts` from config

### Tests (14 new)
- `check_ssrf` blocks localhost, private IPv4, loopback, link-local/metadata, IPv6 loopback, unspecified
- `check_ssrf` allows public URLs
- `check_ssrf` respects `allowed_hosts` bypass (including case-insensitive matching)
- `check_ssrf` rejects `ftp://` and `file://` schemes
- `ClawHubRegistry` constructor tests for `allowed_hosts`

## Config example (self-hosted registry)

```toml
[tools.skills.clawhub]
base_url = "http://registry.internal.corp"
allowed_hosts = ["registry.internal.corp"]
```

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Server-Side Request Forgery (SSRF) protection with configurable allowed hosts to secure network operations
- Implemented 50 MB size limit for downloaded archives to prevent oversized downloads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->