### PR TITLE
feat(discord): add HTTP CONNECT proxy support for Gateway WebSocket

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -305,11 +305,12 @@ impl DiscordChannel {
                 if trimmed.is_empty() {
                     continue;
                 }
-                // Only return URLs with a parseable http or https scheme; skip
-                // entries like "socks5://..." or malformed values and try the
-                // next candidate instead of surfacing them to the caller.
+                // Only return URLs whose scheme is "http": HTTP CONNECT
+                // tunnelling requires a plain TCP connection to the proxy, so
+                // https:// entries are skipped and the next candidate is tried.
+                // Malformed or unsupported-scheme values are also skipped.
                 match reqwest::Url::parse(trimmed) {
-                    Ok(u) if matches!(u.scheme(), "http" | "https") => {
+                    Ok(u) if u.scheme() == "http" => {
                         return Some(trimmed.to_string());
                     }
                     _ => continue,
@@ -505,24 +506,11 @@ impl DiscordChannel {
     }
 
     async fn connect_gateway(ws_url: &str) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
+        // gateway_proxy_from_env only returns http:// proxy URLs, so we can use
+        // the result directly for HTTP CONNECT tunnelling.
         if let Some(proxy_url) = Self::gateway_proxy_from_env(ws_url) {
-            let scheme = reqwest::Url::parse(&proxy_url)
-                .ok()
-                .map(|u| u.scheme().to_string());
-            if scheme.as_deref() == Some("http") {
-                info!("Discord gateway connecting via HTTP CONNECT proxy from env");
-                return Self::connect_via_http_proxy(ws_url, &proxy_url).await;
-            } else {
-                // CONNECT tunnelling requires a plain-TCP connection to the proxy; an
-                // https:// proxy URL would require a nested TLS session which is not
-                // supported.  Fall through to a direct connect and warn the operator.
-                warn!(
-                    "Discord gateway: proxy URL '{}' does not use http:// scheme; \
-                     HTTP CONNECT tunnelling requires a plain TCP connection to the proxy. \
-                     Falling back to direct WebSocket connect.",
-                    Self::sanitize_proxy_url(&proxy_url)
-                );
-            }
+            info!("Discord gateway connecting via HTTP CONNECT proxy from env");
+            return Self::connect_via_http_proxy(ws_url, &proxy_url).await;
         }
 
         let (ws_stream, _) = connect_async(ws_url)
@@ -1752,6 +1740,49 @@ mod tests {
             .expect("valid base64");
         let creds = String::from_utf8(decoded).expect("valid utf8");
         assert_eq!(creds, "user@corp:p@ss");
+    }
+
+    #[test]
+    fn test_gateway_proxy_env_candidate_fallback() {
+        // When HTTPS_PROXY holds an https:// URL (unusable for CONNECT) and
+        // HTTP_PROXY holds a valid http:// URL, gateway_proxy_from_env must
+        // skip the https entry and return the http one.
+        //
+        // Note: std::env::set_var is inherently not thread-safe; this test
+        // must not run concurrently with other tests that touch the same vars.
+        let https_key = "HTTPS_PROXY";
+        let http_key = "HTTP_PROXY";
+        // Save any pre-existing values so we can restore them afterwards.
+        let saved_https = std::env::var(https_key).ok();
+        let saved_http = std::env::var(http_key).ok();
+
+        unsafe {
+            std::env::set_var(https_key, "https://proxy.example.com:3128");
+            std::env::set_var(http_key, "http://proxy.example.com:3128");
+        }
+
+        // Discord gateway uses wss://, so HTTPS_PROXY is tried first.
+        let result =
+            DiscordChannel::gateway_proxy_from_env("wss://gateway.discord.gg/?v=10&encoding=json");
+
+        // Restore env before asserting (ensures cleanup even on panic via
+        // the assert macro, which unwinds through this scope).
+        unsafe {
+            match &saved_https {
+                Some(v) => std::env::set_var(https_key, v),
+                None => std::env::remove_var(https_key),
+            }
+            match &saved_http {
+                Some(v) => std::env::set_var(http_key, v),
+                None => std::env::remove_var(http_key),
+            }
+        }
+
+        assert_eq!(
+            result.as_deref(),
+            Some("http://proxy.example.com:3128"),
+            "https:// HTTPS_PROXY must be skipped; http:// HTTP_PROXY must be returned"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  The Discord Gateway WebSocket connection currently dials the target host directly. In environments that route outbound traffic through an HTTP forward proxy (corporate networks,  containerized deployments, GKE pods with egress policy), the connection fails or is silently dropped.

  This PR introduces transparent HTTP CONNECT proxy tunnelling for the Discord Gateway WebSocket, matching the behaviour users already expect from environment-variable-driven proxy  configuration.

## Changes

  - **`connect_gateway()`** — new dispatcher that checks `HTTPS_PROXY` / `HTTP_PROXY` env vars (in scheme-preference order) before falling back to the existing direct `connect_async`
   path; no behaviour change when no proxy is configured.
  - **`connect_via_http_proxy()`** — establishes a raw TCP connection to the proxy, issues an `HTTP CONNECT` tunnel request to the Discord Gateway host, reads and validates the `200
  Connection Established` response, then performs the WebSocket + TLS handshake over the tunnelled stream via `client_async_tls`.
  - **`parse_proxy_url()`** — validates the proxy URL (must use `http://` scheme), extracts host/port, and encodes `Basic` `Proxy-Authorization` credentials when present in the URL.
  - **`gateway_proxy_from_env()`** — reads standard `HTTPS_PROXY` / `HTTP_PROXY` / lowercase variants, preferring the HTTPS family for `wss://` targets.
  - **`nono_proxy_auth_header()`** — optional `NONO_PROXY_TOKEN` env var for Bearer-token proxy authentication (useful with nono-proxy or similar token-gated proxies).
  - **`build_connect_request()` / `parse_connect_response_ok()`** — pure helpers for constructing and validating the HTTP CONNECT handshake.
  - **`MAX_PROXY_CONNECT_RESPONSE_BYTES`** constant — caps the response buffer to 8 KB to prevent unbounded reads from a misbehaving proxy.
  - **4 new unit tests** covering proxy URL parsing (with/without auth), scheme rejection, and CONNECT response parsing.

## Behaviour

  | Environment | Result |
  |---|---|
  | No proxy env vars set | Direct WebSocket connection (unchanged) |
  | `HTTPS_PROXY=http://proxy:3128` | Tunnel via HTTP CONNECT |
  | `HTTPS_PROXY=http://user:pass@proxy:3128` | Tunnel with Basic auth |
  | `NONO_PROXY_TOKEN=<token>` (+ proxy URL) | Tunnel with Bearer token auth |

## Testing

  ```bash
  cargo test --lib test_parse_proxy
  cargo test --lib test_parse_connect_response
  cargo test --lib

  Checklist

  - cargo fmt — no diffs
  - cargo clippy -- -D warnings — no warnings
  - cargo test --lib — all tests pass
  - No behaviour change when proxy env vars are absent

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP proxy support for Discord gateway WebSocket connections with environment-based discovery and automatic fallback to direct connections.
  * Optional proxy authentication via Basic auth or bearer token, improved connection logging, and safeguards against oversized proxy responses.

* **Tests**
  * Added tests covering proxy URL parsing and CONNECT response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->