### PR TITLE
feat(lark): enable Markdown rendering in Feishu/Lark

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -1087,11 +1087,17 @@ impl Channel for LarkChannel {
             self.api_base(),
             receive_id_type
         );
-        let content = serde_json::json!({ "text": msg.content }).to_string();
+        let card = serde_json::json!({
+            "config": { "wide_screen_mode": true },
+            "elements": [{
+                "tag": "markdown",
+                "content": msg.content,
+            }]
+        });
         let body = serde_json::json!({
             "receive_id": msg.chat_id,
-            "msg_type":   "text",
-            "content":    content,
+            "msg_type":   "interactive",
+            "content":    card.to_string(),
         });
 
         let (status, response) = self
@@ -1441,5 +1447,30 @@ mod tests {
             "open_id"
         };
         assert_eq!(receive_id_type, "open_id");
+    }
+
+    // ---- interactive card payload ----
+
+    #[test]
+    fn test_send_payload_uses_interactive_card() {
+        let content = "Here is **bold** and `code`";
+        let card = serde_json::json!({
+            "config": { "wide_screen_mode": true },
+            "elements": [{
+                "tag": "markdown",
+                "content": content,
+            }]
+        });
+        let body = serde_json::json!({
+            "receive_id": "oc_test",
+            "msg_type":   "interactive",
+            "content":    card.to_string(),
+        });
+        assert_eq!(body["msg_type"], "interactive");
+        let parsed_card: serde_json::Value =
+            serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
+        assert_eq!(parsed_card["elements"][0]["tag"], "markdown");
+        assert_eq!(parsed_card["elements"][0]["content"], content);
+        assert_eq!(parsed_card["config"]["wide_screen_mode"], true);
     }
 }


### PR DESCRIPTION
## Summary

- Switch Lark channel outbound messages from `msg_type: "text"` to `msg_type: "interactive"` message cards
- Uses Feishu's native `markdown` element inside the card so bold, code, lists, and links render properly
- Adds unit test verifying the interactive card payload structure

Closes #266

## Test plan

- [x] All 27 lark channel tests pass (26 existing + 1 new)
- [x] Full test suite: 3033 passed, 0 failed
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean
- [ ] Manual verification with a Feishu bot (send a message with **bold**, `code`, and [links](url))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lark channel now sends messages as interactive cards with enhanced formatting capabilities and wide-screen display optimization, replacing plain text message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->