### PR TITLE
chore: add code coverage with cargo-llvm-cov + Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      - uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2.68.19
+      - uses: taiki-e/install-action@f23382d582832e41d5eb4fff2bddb06bc5adf8d3 # v2.68.21
         with:
           tool: nextest
       - run: cargo nextest run --lib


### PR DESCRIPTION
## Summary
- Add `coverage` job to CI using `cargo-llvm-cov` + `cargo-nextest` for LCOV report generation
- Upload coverage to Codecov via `codecov/codecov-action@v5.5.2`
- Non-blocking (`fail_ci_if_error: false`) so coverage gaps don't break CI initially
- All action versions pinned with commit SHAs matching existing CI conventions

Requested by @reneleonhardt in #183.

Closes #275

## Test plan
- [ ] CI `Coverage` job runs successfully on this PR
- [ ] LCOV report is generated and uploaded to Codecov
- [ ] Existing CI jobs (test, clippy, fmt, audit) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated coverage job in CI to run coverage collection and reporting.
  * Improved coverage measurement for the codebase and upload of coverage data to the reporting service.
  * CI now caches coverage artifacts and uses tooling to produce lcov output; upload failures won’t break the pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->