### PR TITLE
fix(onboard): treat HTTP 429 as valid during API key validation

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -461,16 +461,18 @@ pub(crate) async fn create_agent_with_template(
 pub(crate) enum KeyValidation {
     /// Key confirmed valid (2xx response).
     Valid,
-    /// Key recognized by server but currently rate-limited (429).
-    /// Common for new free-tier accounts.
+    /// Key recognized by server but the account is not currently usable (429).
+    /// This typically indicates rate limiting and can also indicate quota
+    /// exhaustion, depending on the provider.
     RateLimited,
 }
 
 /// Validate an API key by making a minimal API call.
 ///
-/// HTTP 429 (rate limited) returns `Ok(RateLimited)` — the server recognized
-/// the key, confirming it is valid. New free-tier accounts commonly hit rate
-/// limits immediately, so surfacing this as a validation failure is confusing.
+/// HTTP 429 returns `Ok(RateLimited)` — the server recognized the key, so it is
+/// not an authentication failure. Providers use 429 for rate limiting and, in
+/// some cases, quota exhaustion, so onboarding should not report it as an
+/// invalid key.
 pub(crate) async fn validate_api_key(
     provider: &str,
     api_key: &str,

--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -571,9 +571,9 @@ async fn configure_anthropic(config: &mut Config) -> Result<()> {
                 io::stdout().flush()?;
                 match super::common::validate_api_key("anthropic", &api_key, None).await {
                     Ok(super::common::KeyValidation::Valid) => println!(" valid!"),
-                    Ok(super::common::KeyValidation::RateLimited) => {
-                        println!(" valid! (rate-limited, normal for new accounts)");
-                    }
+                    Ok(super::common::KeyValidation::RateLimited) => println!(
+                        " valid! (key recognized, but the account is currently rate-limited or out of quota)"
+                    ),
                     Err(e) => {
                         println!(" failed.");
                         println!("  Warning: {}", e);
@@ -689,9 +689,9 @@ async fn configure_openai(config: &mut Config) -> Result<()> {
             .and_then(|p| p.api_base.as_deref());
         match super::common::validate_api_key("openai", &api_key, existing_base).await {
             Ok(super::common::KeyValidation::Valid) => println!(" valid!"),
-            Ok(super::common::KeyValidation::RateLimited) => {
-                println!(" valid! (rate-limited, normal for new accounts)");
-            }
+            Ok(super::common::KeyValidation::RateLimited) => println!(
+                " valid! (key recognized, but the account is currently rate-limited or out of quota)"
+            ),
             Err(e) => {
                 println!(" failed.");
                 println!("  Warning: {}", e);
@@ -756,9 +756,9 @@ async fn configure_openrouter(config: &mut Config) -> Result<()> {
             .and_then(|p| p.api_base.as_deref());
         match super::common::validate_api_key("openrouter", &api_key, existing_base).await {
             Ok(super::common::KeyValidation::Valid) => println!(" valid!"),
-            Ok(super::common::KeyValidation::RateLimited) => {
-                println!(" valid! (rate-limited, normal for new accounts)");
-            }
+            Ok(super::common::KeyValidation::RateLimited) => println!(
+                " valid! (key recognized, but the account is currently rate-limited or out of quota)"
+            ),
             Err(e) => {
                 println!(" failed.");
                 println!("  Warning: {}", e);


### PR DESCRIPTION
## Summary
- New free-tier accounts hit rate limits on their first API call during `zeptoclaw onboard`, showing a confusing "failed" + "Rate limited" message when the key is actually valid
- A 429 means the server *recognized* the key (unlike 401), so it confirms validity
- Added `KeyValidation` enum (`Valid` / `RateLimited`) so onboard prints `"valid! (rate-limited, normal for new accounts)"` instead of failing

Closes #292

## Test plan
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 13/13 `cli::common` tests pass (6 new: 3 for 429→RateLimited, 3 for 401→Err)
- [x] 3114/3114 lib tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key validation now distinguishes Valid vs Rate-Limited across providers, improving accuracy of validation feedback.
  * Onboarding messages updated: rate-limited keys now show a clarifying note ("key recognized, but ... rate-limited or out of quota") while valid keys keep the original confirmation.
* **Bug Fixes**
  * Invalid-key responses now produce clearer, friendly error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->