### PR TITLE
feat: model-provider compatibility validation

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -39,7 +39,7 @@ async fn cmd_config_check() -> Result<()> {
         println!("{}", diag);
     }
 
-    let errors = diagnostics
+    let mut errors = diagnostics
         .iter()
         .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Error)
         .count();
@@ -55,6 +55,20 @@ async fn cmd_config_check() -> Result<()> {
         println!("[WARN] {}", w);
     }
     warnings += tool_warnings.len();
+
+    // Model-provider compatibility
+    let model_diags = zeptoclaw::config::validate::validate_model_provider_compat(&config);
+    for diag in &model_diags {
+        println!("{}", diag);
+    }
+    errors += model_diags
+        .iter()
+        .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Error)
+        .count();
+    warnings += model_diags
+        .iter()
+        .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Warn)
+        .count();
 
     // Hint: workspace configured but coding tools disabled
     let workspace = config.workspace_path();

--- a/src/cli/gateway.rs
+++ b/src/cli/gateway.rs
@@ -257,6 +257,38 @@ pub(crate) async fn cmd_gateway(
         None
     };
 
+    // Preflight: validate model-provider compatibility before starting anything.
+    if !containerized {
+        let model_diags = zeptoclaw::config::validate::validate_model_provider_compat(&config);
+        for diag in &model_diags {
+            match diag.level {
+                zeptoclaw::config::validate::DiagnosticLevel::Error => {
+                    error!("{}", diag);
+                }
+                zeptoclaw::config::validate::DiagnosticLevel::Warn => {
+                    warn!("{}", diag);
+                }
+                zeptoclaw::config::validate::DiagnosticLevel::Ok => {
+                    info!("{}", diag);
+                }
+            }
+        }
+        let has_errors = model_diags
+            .iter()
+            .any(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Error);
+        if has_errors {
+            eprintln!();
+            eprintln!("ERROR: Model-provider mismatch detected.");
+            eprintln!(
+                "  Fix your config ({:?}) or run 'zeptoclaw onboard'.",
+                Config::path()
+            );
+            eprintln!("  Run 'zeptoclaw config check' for details.");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
+
     // Create in-process agent (only needed when not containerized)
     let mut agent = if !containerized {
         let agent = create_agent(config.clone(), bus.clone()).await?;

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -263,6 +263,123 @@ pub fn validate_config(raw: &Value) -> Vec<Diagnostic> {
     diagnostics
 }
 
+/// Check if a model name looks compatible with a provider backend.
+///
+/// Returns `None` when the combination is fine, or `Some(message)` describing
+/// the mismatch.
+fn check_model_backend_compat(model: &str, provider_name: &str, backend: &str) -> Option<String> {
+    let m = model.to_lowercase();
+
+    match backend {
+        "anthropic" => {
+            // Claude models always start with "claude-"
+            if !m.starts_with("claude-") {
+                Some(format!(
+                    "model '{}' does not look like a Claude model (expected 'claude-*') \
+                     but provider '{}' uses the Anthropic API",
+                    model, provider_name,
+                ))
+            } else {
+                None
+            }
+        }
+        "openai" => {
+            // OpenAI-compatible providers accept many model formats, but a
+            // `claude-*` model is almost certainly wrong for the OpenAI backend.
+            if m.starts_with("claude-") && provider_name == "openai" {
+                Some(format!(
+                    "model '{}' looks like a Claude model but provider '{}' uses the OpenAI API",
+                    model, provider_name,
+                ))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Validate that the configured default model is compatible with the
+/// resolved primary provider.
+///
+/// Also validates per-provider model overrides.
+pub fn validate_model_provider_compat(config: &crate::config::Config) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    let default_model = &config.agents.defaults.model;
+
+    // Use the provider registry to figure out which providers are actually
+    // resolved at runtime (have credentials).
+    let selections = crate::providers::resolve_runtime_providers(config);
+
+    if selections.is_empty() {
+        diags.push(Diagnostic {
+            level: DiagnosticLevel::Warn,
+            path: "providers".to_string(),
+            message: "No AI provider resolved \u{2014} set an API key or run 'zeptoclaw onboard'"
+                .to_string(),
+        });
+        return diags;
+    }
+
+    // Check default model against primary (first resolved) provider.
+    let primary = &selections[0];
+    if let Some(msg) = check_model_backend_compat(default_model, primary.name, primary.backend) {
+        // If the provider has a per-provider model override, the default
+        // model mismatch is just a warning (per-provider model takes
+        // precedence at runtime).
+        let level = if primary.model.is_some() {
+            DiagnosticLevel::Warn
+        } else {
+            DiagnosticLevel::Error
+        };
+
+        let mut message = msg;
+        if let Some(ref per_model) = primary.model {
+            message.push_str(&format!(
+                " (per-provider model '{}' will be used instead)",
+                per_model
+            ));
+        } else {
+            message.push_str(
+                ". Fix: set 'agents.defaults.model' to a compatible model, \
+                 or add 'providers.<name>.model' override",
+            );
+        }
+
+        diags.push(Diagnostic {
+            level,
+            path: "agents.defaults.model".to_string(),
+            message,
+        });
+    }
+
+    // Check per-provider model overrides against their own backend.
+    for sel in &selections {
+        if let Some(ref per_model) = sel.model {
+            if let Some(msg) = check_model_backend_compat(per_model, sel.name, sel.backend) {
+                diags.push(Diagnostic {
+                    level: DiagnosticLevel::Error,
+                    path: format!("providers.{}.model", sel.name),
+                    message: msg,
+                });
+            }
+        }
+    }
+
+    if diags.is_empty() {
+        diags.push(Diagnostic {
+            level: DiagnosticLevel::Ok,
+            path: String::new(),
+            message: format!(
+                "Model '{}' compatible with primary provider '{}'",
+                default_model, primary.name
+            ),
+        });
+    }
+
+    diags
+}
+
 /// Validate custom tool definitions.
 pub fn validate_custom_tools(config: &crate::config::Config) -> Vec<String> {
     let mut warnings = Vec::new();
@@ -545,5 +662,63 @@ mod tests {
                 .any(|d| { d.path.contains("loop_guard.enbled") && d.message.contains("enabled") }),
             "Expected suggestion for typo 'enbled'"
         );
+    }
+
+    // --- Model-provider compatibility unit tests ---
+
+    #[test]
+    fn test_compat_claude_model_on_anthropic() {
+        let result =
+            check_model_backend_compat("claude-sonnet-4-5-20250929", "anthropic", "anthropic");
+        assert!(result.is_none(), "Claude model should be fine on anthropic");
+    }
+
+    #[test]
+    fn test_compat_gpt_model_on_anthropic() {
+        let result = check_model_backend_compat("gpt-5.1-2025-11-13", "anthropic", "anthropic");
+        assert!(
+            result.is_some(),
+            "GPT model should NOT be compatible with anthropic"
+        );
+        assert!(result
+            .unwrap()
+            .contains("does not look like a Claude model"));
+    }
+
+    #[test]
+    fn test_compat_gpt_model_on_openai() {
+        let result = check_model_backend_compat("gpt-5.1", "openai", "openai");
+        assert!(result.is_none(), "GPT model should be fine on openai");
+    }
+
+    #[test]
+    fn test_compat_claude_model_on_openai() {
+        let result = check_model_backend_compat("claude-sonnet-4-5-20250929", "openai", "openai");
+        assert!(
+            result.is_some(),
+            "Claude model should NOT be compatible with openai"
+        );
+    }
+
+    #[test]
+    fn test_compat_custom_model_on_groq() {
+        // Groq uses openai backend but has custom model names
+        let result = check_model_backend_compat("llama-3.3-70b", "groq", "openai");
+        assert!(
+            result.is_none(),
+            "Custom model should be fine on OpenAI-compat provider"
+        );
+    }
+
+    #[test]
+    fn test_compat_case_insensitive() {
+        let result = check_model_backend_compat("Claude-Sonnet-4-5", "anthropic", "anthropic");
+        assert!(result.is_none(), "Case-insensitive match should work");
+    }
+
+    #[test]
+    fn test_compat_openrouter_auto_on_openai() {
+        let result = check_model_backend_compat("openrouter/auto", "openrouter", "openai");
+        assert!(result.is_none(), "openrouter/auto should be fine");
     }
 }


### PR DESCRIPTION
## Summary
- Add preflight model-provider compatibility check at gateway startup — catches mismatches like `gpt-5.1` on Anthropic API before the first message fails
- Wire validation into `config check` command for proactive diagnostics
- Detect per-provider model overrides and only warn (not error) when per-provider model is set

## What it catches
- `gpt-*` model configured as default with Anthropic as primary provider → **ERROR** (exits gateway)
- `claude-*` model configured as default with native OpenAI as primary provider → **ERROR**
- Custom models on OpenAI-compatible providers (groq, deepseek, etc.) → **OK** (no false positives)
- Model mismatch when per-provider override exists → **WARN** only (override takes precedence)

## Files changed
- `src/config/validate.rs` — `validate_model_provider_compat()` + `check_model_backend_compat()` + 7 unit tests
- `src/cli/config.rs` — Wire model validation into `config check`
- `src/cli/gateway.rs` — Add preflight check before `create_agent()`

## Test plan
- [x] 7 unit tests for model-backend compatibility logic
- [x] Full test suite passes (3091 passed)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-provider compatibility validation. The system validates that configured AI models are compatible with their selected providers during both configuration file loading and gateway startup. When compatibility checks are performed, detailed error and warning diagnostics help users identify and resolve any incompatibilities discovered between their selected models and the specific capabilities of their provider services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->