### PR TITLE
fix(cli): default agent mode to warn-level logging

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -532,12 +532,24 @@ pub async fn run() -> Result<()> {
     // Initialize logging from config (format, level, optional file output).
     // Load config early so we can respect the logging settings; fall back to
     // defaults if the config file is missing or unreadable.
-    let logging_cfg = zeptoclaw::config::Config::load()
+    let cli = Cli::parse();
+
+    let mut logging_cfg = zeptoclaw::config::Config::load()
         .map(|c| c.logging)
         .unwrap_or_default();
-    zeptoclaw::utils::logging::init_logging(&logging_cfg);
 
-    let cli = Cli::parse();
+    // CLI agent mode defaults to warn-level logging to keep output clean.
+    // Gateway and other long-running modes keep info-level for operational visibility.
+    // Users can still override with RUST_LOG=info.
+    if matches!(
+        cli.command,
+        Some(Commands::Agent { .. } | Commands::Batch { .. })
+    ) && std::env::var("RUST_LOG").is_err()
+    {
+        logging_cfg.level = "warn".to_string();
+    }
+
+    zeptoclaw::utils::logging::init_logging(&logging_cfg);
 
     match cli.command {
         None => {


### PR DESCRIPTION
## Summary
- CLI `agent` and `batch` commands now default to `warn`-level logging instead of `info`
- Gateway and other long-running modes keep `info`-level for operational visibility
- Users can still override with `RUST_LOG=info zeptoclaw agent -m "test"`

Closes #312

## Test plan
- [ ] `zeptoclaw agent -m "test"` produces clean output (no provider/tool/cron registration logs)
- [ ] `zeptoclaw gateway` still shows info-level startup logs
- [ ] `RUST_LOG=info zeptoclaw agent -m "test"` shows verbose logs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted default logging verbosity for Agent and Batch commands. These commands now default to warning-level output when the log level is not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->