### PR TITLE
feat(cli): add zeptoclaw uninstall command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ Project-level guidance for coding agents working in this repository.
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
 - MCP transport: supports both HTTP and stdio MCP servers (`url` or `command` + args/env) with tool registration during `create_agent()`
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
+- Uninstall CLI: `zeptoclaw uninstall` removes `~/.zeptoclaw`; `--remove-binary` deletes direct installs in `~/.local/bin` or `/usr/local/bin` and defers Homebrew/Cargo binaries to their package managers
 - Process exit codes: explicit `main` mapping for success (0) and error (1); uncaught panic/crash remains Rust default (101)
-- Tests: default build runs 2956 lib + 92 main + 23 cli_smoke + 13 e2e + 70 integration + 126 doc (27 ignored); optional features such as `whatsapp-web` add feature-gated coverage
+- Tests: default build runs 3090 lib (3084 passed, 6 ignored) + 92 main + 24 cli_smoke + 13 e2e + 70 integration + 127 doc (27 ignored); optional features such as `whatsapp-web` add feature-gated coverage
 
 ## Task Tracking Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ cargo clippy -- -D warnings
 cargo fmt
 
 # Test counts (cargo test)
-# default build: lib 2956, main 92, cli_smoke 23, e2e 13, integration 70, doc 126 passed (27 ignored); optional features such as whatsapp-web add feature-gated coverage
+# default build: lib 3090 total (3084 passed, 6 ignored), main 92, cli_smoke 24, e2e 13, integration 70, doc 127 passed (27 ignored); optional features such as whatsapp-web add feature-gated coverage
 
 # Version
 ./target/release/zeptoclaw --version
@@ -141,6 +141,10 @@ cargo release patch --execute  # actually bump, commit, tag, push, publish to cr
 ./target/release/zeptoclaw update --check      # check without downloading
 ./target/release/zeptoclaw update --version v0.5.2  # specific version
 ./target/release/zeptoclaw update --force      # re-download even if current
+
+# Uninstall
+./target/release/zeptoclaw uninstall --yes
+./target/release/zeptoclaw uninstall --remove-binary --yes
 
 # Per-provider quota management
 ./target/release/zeptoclaw quota status
@@ -260,6 +264,7 @@ src/
 │   ├── tools.rs    # Tool discovery list/info + dynamic status summary
 │   ├── hand.rs     # Hands-lite list/activate/deactivate/status commands
 │   ├── provider.rs # Provider chain status introspection (resolved providers, wrappers, quota)
+│   ├── uninstall.rs # State removal + guarded binary uninstall command
 │   └── watch.rs    # URL change monitoring with channel notification
 ├── config/         # Configuration types/loading + hot-reload watcher (mtime polling)
 ├── hands/          # HAND.toml manifest parsing + built-in hands registry

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ docker pull ghcr.io/qhkm/zeptoclaw:latest
 cargo install zeptoclaw --git https://github.com/qhkm/zeptoclaw
 ```
 
+## Uninstall
+
+```bash
+# Remove ZeptoClaw state (~/.zeptoclaw)
+zeptoclaw uninstall --yes
+
+# Also remove a direct-install binary from ~/.local/bin or /usr/local/bin
+zeptoclaw uninstall --remove-binary --yes
+
+# Package-managed installs still use their package manager
+brew uninstall qhkm/tap/zeptoclaw
+cargo uninstall zeptoclaw
+```
+
 ## Quick Start
 
 ```bash

--- a/landing/zeptoclaw/docs/src/content/docs/getting-started/installation.md
+++ b/landing/zeptoclaw/docs/src/content/docs/getting-started/installation.md
@@ -95,6 +95,24 @@ zeptoclaw --help
 # Shows available commands
 ```
 
+## Uninstall
+
+Use the built-in uninstall command to remove ZeptoClaw state:
+
+```bash
+zeptoclaw uninstall --yes
+
+# Also remove a direct-install binary from ~/.local/bin or /usr/local/bin
+zeptoclaw uninstall --remove-binary --yes
+```
+
+If you installed ZeptoClaw with a package manager, remove the binary with the same tool:
+
+```bash
+brew uninstall qhkm/tap/zeptoclaw
+cargo uninstall zeptoclaw
+```
+
 ## Next steps
 
 Now that ZeptoClaw is installed, follow the [quick start guide](/docs/getting-started/quick-start/) to run your first agent interaction.

--- a/landing/zeptoclaw/docs/src/content/docs/reference/cli.md
+++ b/landing/zeptoclaw/docs/src/content/docs/reference/cli.md
@@ -184,6 +184,29 @@ View heartbeat service status.
 zeptoclaw heartbeat --show
 ```
 
+## uninstall
+
+Remove ZeptoClaw state and optionally the current binary.
+
+```bash
+zeptoclaw uninstall [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--remove-binary` | Remove the current binary for direct installs in `~/.local/bin` or `/usr/local/bin` |
+| `-y, --yes` | Skip the confirmation prompt |
+
+### Examples
+
+```bash
+# Remove ~/.zeptoclaw
+zeptoclaw uninstall --yes
+
+# Remove ~/.zeptoclaw and a direct-install binary
+zeptoclaw uninstall --remove-binary --yes
+```
+
 ## skills
 
 Manage agent skills.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub mod skills;
 pub mod status;
 pub mod template;
 pub mod tools;
+pub mod uninstall;
 pub mod update;
 pub mod watch;
 
@@ -246,6 +247,15 @@ enum Commands {
         /// Force re-download even if already on latest
         #[arg(long)]
         force: bool,
+    },
+    /// Remove ZeptoClaw state and optionally the current binary
+    Uninstall {
+        /// Also remove the current zeptoclaw binary for direct file installs
+        #[arg(long)]
+        remove_binary: bool,
+        /// Skip the confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
     },
     /// Hardware device management (USB discovery, peripherals)
     Hardware {
@@ -659,6 +669,9 @@ pub async fn run() -> Result<()> {
             force,
         }) => {
             update::cmd_update(check, version, force).await?;
+        }
+        Some(Commands::Uninstall { remove_binary, yes }) => {
+            uninstall::cmd_uninstall(remove_binary, yes).await?;
         }
         Some(Commands::Hardware { action }) => {
             cmd_hardware(action);

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -1,0 +1,273 @@
+//! `zeptoclaw uninstall` command — remove ZeptoClaw state and optional binary.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use zeptoclaw::config::Config;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BinaryRemovalPlan {
+    Keep,
+    Remove(PathBuf),
+    Manual {
+        reason: String,
+        command: Option<String>,
+    },
+}
+
+pub(crate) async fn cmd_uninstall(remove_binary: bool, yes: bool) -> Result<()> {
+    let state_dir = Config::dir();
+    let state_exists = state_dir.exists();
+    let binary_plan = if remove_binary {
+        current_binary_removal_plan()?
+    } else {
+        BinaryRemovalPlan::Keep
+    };
+
+    print_uninstall_plan(&state_dir, state_exists, &binary_plan, remove_binary);
+
+    let will_remove_binary = matches!(&binary_plan, BinaryRemovalPlan::Remove(_));
+    let has_destructive_action = state_exists || will_remove_binary;
+
+    if !has_destructive_action {
+        println!();
+        match binary_plan {
+            BinaryRemovalPlan::Keep => {
+                println!("Nothing to uninstall.");
+            }
+            BinaryRemovalPlan::Manual { reason, command } => {
+                println!("Binary was not removed automatically: {reason}");
+                if let Some(command) = command {
+                    println!("Remove it with: {command}");
+                }
+            }
+            BinaryRemovalPlan::Remove(_) => {}
+        }
+        return Ok(());
+    }
+
+    if !yes && !confirm_uninstall()? {
+        println!("Uninstall cancelled.");
+        return Ok(());
+    }
+
+    if state_exists {
+        tokio::fs::remove_dir_all(&state_dir)
+            .await
+            .with_context(|| format!("failed to remove state directory {}", state_dir.display()))?;
+        println!("Removed state directory: {}", state_dir.display());
+    } else {
+        println!("State directory not found: {}", state_dir.display());
+    }
+
+    match binary_plan {
+        BinaryRemovalPlan::Keep => {
+            println!("Kept current binary. Re-run with --remove-binary to delete direct installs.");
+        }
+        BinaryRemovalPlan::Remove(path) => {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("failed to remove binary {}", path.display()))?;
+            println!("Removed binary: {}", path.display());
+        }
+        BinaryRemovalPlan::Manual { reason, command } => {
+            println!("Binary was not removed automatically: {reason}");
+            if let Some(command) = command {
+                println!("Remove it with: {command}");
+            }
+        }
+    }
+
+    println!("ZeptoClaw uninstall complete.");
+    Ok(())
+}
+
+fn confirm_uninstall() -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        bail!("refusing to uninstall in non-interactive mode without --yes");
+    }
+
+    print!("Proceed with uninstall? [y/N]: ");
+    io::stdout().flush().context("failed to flush stdout")?;
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .context("failed to read confirmation response")?;
+
+    let input = input.trim();
+    Ok(input.eq_ignore_ascii_case("y") || input.eq_ignore_ascii_case("yes"))
+}
+
+fn print_uninstall_plan(
+    state_dir: &Path,
+    state_exists: bool,
+    binary_plan: &BinaryRemovalPlan,
+    remove_binary: bool,
+) {
+    println!("ZeptoClaw uninstall");
+    println!();
+    if state_exists {
+        println!("State directory to remove: {}", state_dir.display());
+    } else {
+        println!("State directory not found: {}", state_dir.display());
+    }
+
+    match binary_plan {
+        BinaryRemovalPlan::Keep => {
+            if remove_binary {
+                println!("Binary removal skipped.");
+            } else {
+                println!("Binary will be kept. Use --remove-binary for direct installs.");
+            }
+        }
+        BinaryRemovalPlan::Remove(path) => {
+            println!("Binary to remove: {}", path.display());
+        }
+        BinaryRemovalPlan::Manual { reason, command } => {
+            println!("Binary will not be removed automatically: {reason}");
+            if let Some(command) = command {
+                println!("Suggested manual command: {command}");
+            }
+        }
+    }
+}
+
+fn current_binary_removal_plan() -> Result<BinaryRemovalPlan> {
+    let raw = std::env::current_exe().context("failed to determine current executable path")?;
+    let resolved = raw.canonicalize().unwrap_or_else(|_| raw.clone());
+    Ok(binary_removal_plan_for_paths(&raw, &resolved))
+}
+
+fn binary_removal_plan_for_paths(raw: &Path, resolved: &Path) -> BinaryRemovalPlan {
+    if is_homebrew_install(raw) || is_homebrew_install(resolved) {
+        return BinaryRemovalPlan::Manual {
+            reason: format!(
+                "the current binary appears to be managed by Homebrew at {}",
+                resolved.display()
+            ),
+            command: Some("brew uninstall qhkm/tap/zeptoclaw".to_string()),
+        };
+    }
+
+    if is_cargo_install(raw) || is_cargo_install(resolved) {
+        return BinaryRemovalPlan::Manual {
+            reason: format!(
+                "the current binary appears to be managed by cargo-install at {}",
+                resolved.display()
+            ),
+            command: Some("cargo uninstall zeptoclaw".to_string()),
+        };
+    }
+
+    if is_direct_install_path(raw) {
+        return BinaryRemovalPlan::Remove(raw.to_path_buf());
+    }
+
+    if is_direct_install_path(resolved) {
+        return BinaryRemovalPlan::Remove(resolved.to_path_buf());
+    }
+
+    BinaryRemovalPlan::Manual {
+        reason: format!(
+            "automatic binary removal only supports direct installs in ~/.local/bin or /usr/local/bin (current path: {})",
+            resolved.display()
+        ),
+        command: None,
+    }
+}
+
+fn is_direct_install_path(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| name == std::ffi::OsStr::new("zeptoclaw"))
+        && supported_direct_install_dirs()
+            .iter()
+            .any(|dir| path.starts_with(dir))
+}
+
+fn is_cargo_install(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| name == std::ffi::OsStr::new("zeptoclaw"))
+        && dirs::home_dir()
+            .map(|home| path.starts_with(home.join(".cargo/bin")))
+            .unwrap_or(false)
+}
+
+fn is_homebrew_install(path: &Path) -> bool {
+    let text = path.to_string_lossy();
+    text.contains("/Cellar/")
+        || text.starts_with("/opt/homebrew/bin/zeptoclaw")
+        || text.starts_with("/home/linuxbrew/.linuxbrew/bin/zeptoclaw")
+}
+
+fn supported_direct_install_dirs() -> Vec<PathBuf> {
+    let mut install_dirs = vec![PathBuf::from("/usr/local/bin")];
+    if let Some(home) = dirs::home_dir() {
+        install_dirs.push(home.join(".local/bin"));
+    }
+    install_dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_direct_install_in_local_bin_is_removable() {
+        let home = dirs::home_dir().expect("home dir");
+        let path = home.join(".local/bin/zeptoclaw");
+        let plan = binary_removal_plan_for_paths(&path, &path);
+        assert_eq!(plan, BinaryRemovalPlan::Remove(path));
+    }
+
+    #[test]
+    fn plan_direct_install_in_usr_local_bin_is_removable() {
+        let path = PathBuf::from("/usr/local/bin/zeptoclaw");
+        let plan = binary_removal_plan_for_paths(&path, &path);
+        assert_eq!(plan, BinaryRemovalPlan::Remove(path));
+    }
+
+    #[test]
+    fn plan_homebrew_install_requires_manual_uninstall() {
+        let raw = PathBuf::from("/opt/homebrew/bin/zeptoclaw");
+        let resolved = PathBuf::from("/opt/homebrew/Cellar/zeptoclaw/0.5.0/bin/zeptoclaw");
+        let plan = binary_removal_plan_for_paths(&raw, &resolved);
+        match plan {
+            BinaryRemovalPlan::Manual { reason, command } => {
+                assert!(reason.contains("Homebrew"));
+                assert_eq!(
+                    command.as_deref(),
+                    Some("brew uninstall qhkm/tap/zeptoclaw")
+                );
+            }
+            other => panic!("expected manual plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_cargo_install_requires_manual_uninstall() {
+        let home = dirs::home_dir().expect("home dir");
+        let path = home.join(".cargo/bin/zeptoclaw");
+        let plan = binary_removal_plan_for_paths(&path, &path);
+        match plan {
+            BinaryRemovalPlan::Manual { reason, command } => {
+                assert!(reason.contains("cargo-install"));
+                assert_eq!(command.as_deref(), Some("cargo uninstall zeptoclaw"));
+            }
+            other => panic!("expected manual plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_unknown_binary_path_stays_manual() {
+        let path = PathBuf::from("/tmp/zeptoclaw");
+        let plan = binary_removal_plan_for_paths(&path, &path);
+        match plan {
+            BinaryRemovalPlan::Manual { reason, command } => {
+                assert!(reason.contains("automatic binary removal only supports"));
+                assert!(command.is_none());
+            }
+            other => panic!("expected manual plan, got {other:?}"),
+        }
+    }
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -274,3 +274,10 @@ fn cli_gateway_help() {
     assert_eq!(code, 0);
     assert!(stdout.contains("gateway") || stdout.contains("Gateway"));
 }
+
+#[test]
+fn cli_uninstall_help() {
+    let (code, stdout, _stderr) = run_cli(&["uninstall", "--help"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("remove-binary") || stdout.contains("Uninstall"));
+}


### PR DESCRIPTION
## Summary
- add a top-level `zeptoclaw uninstall` command with `--yes` and `--remove-binary`
- remove `~/.zeptoclaw` state by default and guard binary deletion based on install method
- document the command and add a CLI smoke test

## Testing
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --doc
- cargo test --test cli_smoke cli_uninstall_help

`cargo nextest run --lib` could not be run because `cargo-nextest` is not installed in this environment.

Implements #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added uninstall command to remove ZeptoClaw state and configuration
  * Option to remove the binary with `--remove-binary` flag (supports direct installs, Homebrew, and Cargo)

* **Documentation**
  * Updated README with uninstall instructions
  * Added uninstall section to installation documentation
  * Added uninstall command reference with examples and options

* **Tests**
  * Added test coverage for uninstall command help

<!-- end of auto-generated comment: release notes by coderabbit.ai -->