### PR TITLE
fix: deduplicate Claude subscription token warning

### DIFF
--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -407,11 +407,14 @@ fn resolve_credential(
     #[cfg(not(test))]
     if result.is_none() && spec.name == "anthropic" {
         if let Some(token_set) = crate::auth::claude_import::read_claude_credentials() {
-            tracing::warn!(
-                "Using Claude subscription token (unofficial). \
-                 This may violate Anthropic's Terms of Service. \
-                 Set ZEPTOCLAW_PROVIDERS_ANTHROPIC_API_KEY for official API access."
-            );
+            static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+            WARN_ONCE.call_once(|| {
+                tracing::warn!(
+                    "Using Claude subscription token (unofficial). \
+                     This may violate Anthropic's Terms of Service. \
+                     Set ZEPTOCLAW_PROVIDERS_ANTHROPIC_API_KEY for official API access."
+                );
+            });
 
             let credential = ResolvedCredential::BearerToken {
                 access_token: token_set.access_token,


### PR DESCRIPTION
## Summary
- `resolve_credential()` is called 3 times during `zeptoclaw agent` startup (provider availability check, provider chain build, model-switch registry population), each logging the same "Using Claude subscription token" warning
- Wrapped the warning in `std::sync::Once` so it only prints once per process

## Test plan
- [ ] Run `zeptoclaw agent` with no API key configured (Claude CLI credentials only) — verify warning appears exactly once
- [ ] Run `cargo clippy -- -D warnings` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from credential-related warnings by ensuring they appear only once per session instead of repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->