### PR TITLE
chore: validate Zhipu API keys during onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Project-level guidance for coding agents working in this repository.
 - Library facade: `ZeptoAgent::builder()` for embedding as a crate (Tauri, GUI apps)
 - Runtime provider resolution: builds chain in registry order only when `providers.fallback.enabled`; honors `providers.fallback.provider`; can wrap chain with `RetryProvider` via `providers.retry.*`
 - Provider introspection CLI: `zeptoclaw provider status` prints resolved providers, wrapper config (retry/fallback), and quota usage snapshot
+- Provider onboarding validation: Anthropic uses `GET /v1/models`; OpenAI-compatible presets validate keys with read-only endpoint checks, including Zhipu/GLM via `GET /models`
 - Channel dispatch: avoids holding the channels map `RwLock` across async `send()` awaits
 - Channel supervisor: polling (15s) detects dead channels, restarts with 60s cooldown, max 5 restarts
 - Channel panic isolation: Slack/Discord/Webhook/WhatsApp/WhatsApp Web/WhatsApp Cloud/Lark/Email/MQTT/Serial spawned tasks are wrapped with `catch_unwind` and panic logging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,7 @@ Containerized agent proxy for full request isolation:
 ### Providers (`src/providers/`)
 LLM provider abstraction via `LLMProvider` trait:
 - `ClaudeProvider` - Anthropic Claude API (120s timeout, SSE streaming)
-- `OpenAIProvider` - OpenAI Chat Completions API (120s timeout, SSE streaming); supports any OpenAI-compatible endpoint via `api_base` (Ollama, Groq, Together, Fireworks, LM Studio, vLLM, DeepSeek, Kimi/Moonshot, Azure OpenAI, Amazon Bedrock, xAI/Grok, Baidu Qianfan); custom auth header via `auth_header` config field; API version query param via `api_version` field
+- `OpenAIProvider` - OpenAI Chat Completions API (120s timeout, SSE streaming); supports any OpenAI-compatible endpoint via `api_base` (Ollama, Groq, Zhipu/GLM, Together, Fireworks, LM Studio, vLLM, DeepSeek, Kimi/Moonshot, Azure OpenAI, Amazon Bedrock, xAI/Grok, Baidu Qianfan); custom auth header via `auth_header` config field; API version query param via `api_version` field; onboarding key validation includes OpenAI, OpenRouter, and Zhipu via read-only endpoint checks
 - `RetryProvider` - Decorator: exponential backoff on 429/5xx with structured `ProviderError` classification
 - `FallbackProvider` - Decorator: primary → secondary auto-failover with circuit breaker (Closed/Open/HalfOpen)
 - `QuotaProvider` - Decorator: wraps each provider to enforce configurable cost/token quotas; action can reject, failover (triggers FallbackProvider), or warn

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -508,20 +508,11 @@ pub(crate) async fn validate_api_key(
         }
         "openai" => {
             let base = api_base.unwrap_or("https://api.openai.com/v1");
-            let resp = client
-                .get(format!("{}/models", base))
-                .header("Authorization", format!("Bearer {}", api_key))
-                .send()
-                .await?;
-            let status = resp.status().as_u16();
-            if resp.status().is_success() {
-                Ok(KeyValidation::Valid)
-            } else if status == 429 {
-                Ok(KeyValidation::RateLimited)
-            } else {
-                let body = resp.text().await.unwrap_or_default();
-                Err(anyhow::anyhow!(friendly_api_error("openai", status, &body)))
-            }
+            validate_bearer_models_key(&client, "openai", api_key, base).await
+        }
+        "zhipu" => {
+            let base = api_base.unwrap_or("https://open.bigmodel.cn/api/paas/v4");
+            validate_bearer_models_key(&client, "zhipu", api_key, base).await
         }
         "openrouter" => {
             // OpenRouter has a dedicated key info endpoint.
@@ -555,6 +546,28 @@ pub(crate) async fn validate_api_key(
     }
 }
 
+async fn validate_bearer_models_key(
+    client: &reqwest::Client,
+    provider: &str,
+    api_key: &str,
+    base: &str,
+) -> anyhow::Result<KeyValidation> {
+    let resp = client
+        .get(format!("{}/models", base))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await?;
+    let status = resp.status().as_u16();
+    if resp.status().is_success() {
+        Ok(KeyValidation::Valid)
+    } else if status == 429 {
+        Ok(KeyValidation::RateLimited)
+    } else {
+        let body = resp.text().await.unwrap_or_default();
+        Err(anyhow::anyhow!(friendly_api_error(provider, status, &body)))
+    }
+}
+
 /// Map HTTP status to user-friendly error message with actionable guidance.
 pub(crate) fn friendly_api_error(provider: &str, status: u16, body: &str) -> String {
     // Try to extract a message from the provider's JSON error response.
@@ -573,6 +586,7 @@ pub(crate) fn friendly_api_error(provider: &str, status: u16, body: &str) -> Str
             provider,
             match provider {
                 "anthropic" => "Get key: https://console.anthropic.com/",
+                "zhipu" => "Get key: https://open.bigmodel.cn/",
                 "openrouter" => "Get key: https://openrouter.ai/settings/keys",
                 _ => "Get key: https://platform.openai.com/api-keys",
             }
@@ -587,6 +601,7 @@ pub(crate) fn friendly_api_error(provider: &str, status: u16, body: &str) -> Str
                 provider,
                 match provider {
                     "anthropic" => "Billing: https://console.anthropic.com/settings/billing",
+                    "zhipu" => "Billing: https://open.bigmodel.cn/",
                     _ => "Billing: https://platform.openai.com/settings/organization/billing",
                 }
             ),
@@ -742,6 +757,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_api_key_zhipu_429_returns_rate_limited() {
+        let base = spawn_validation_server(
+            "/models",
+            &[("authorization", "Bearer test-key")],
+            429,
+            "{}",
+        )
+        .await;
+
+        let result = validate_api_key("zhipu", "test-key", Some(&base))
+            .await
+            .expect("429 should be treated as a valid key");
+
+        assert_eq!(result, KeyValidation::RateLimited);
+    }
+
+    #[tokio::test]
     async fn test_validate_api_key_openrouter_429_returns_rate_limited() {
         let base =
             spawn_validation_server("/key", &[("authorization", "Bearer test-key")], 429, "{}")
@@ -792,6 +824,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_api_key_zhipu_401_returns_error() {
+        let base = spawn_validation_server(
+            "/models",
+            &[("authorization", "Bearer bad-key")],
+            401,
+            r#"{"error":{"message":"bad key"}}"#,
+        )
+        .await;
+
+        let err = validate_api_key("zhipu", "bad-key", Some(&base))
+            .await
+            .expect_err("401 should remain an error");
+
+        assert!(err.to_string().contains("Invalid API key"));
+        assert!(err.to_string().contains("open.bigmodel.cn"));
+    }
+
+    #[tokio::test]
     async fn test_validate_api_key_openrouter_401_returns_error() {
         let base = spawn_validation_server(
             "/key",
@@ -822,6 +872,14 @@ mod tests {
         assert!(msg.contains("Invalid API key"));
         assert!(msg.contains("openai"));
         assert!(msg.contains("platform.openai.com"));
+    }
+
+    #[test]
+    fn test_friendly_api_error_401_zhipu() {
+        let msg = friendly_api_error("zhipu", 401, "");
+        assert!(msg.contains("Invalid API key"));
+        assert!(msg.contains("zhipu"));
+        assert!(msg.contains("open.bigmodel.cn"));
     }
 
     #[test]

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -651,6 +651,23 @@ mod tests {
     }
 
     #[test]
+    fn test_zhipu_resolves_with_default_base_url() {
+        let mut config = Config::default();
+        config.providers.zhipu = Some(ProviderConfig {
+            api_key: Some("zhipu-test-key".to_string()),
+            ..Default::default()
+        });
+
+        let selected = resolve_runtime_provider(&config).expect("provider should resolve");
+        assert_eq!(selected.name, "zhipu");
+        assert_eq!(selected.backend, "openai");
+        assert_eq!(
+            selected.api_base.as_deref(),
+            Some("https://open.bigmodel.cn/api/paas/v4")
+        );
+    }
+
+    #[test]
     fn test_openai_has_no_default_base_url() {
         let mut config = Config::default();
         config.providers.openai = Some(ProviderConfig {


### PR DESCRIPTION
## Summary
- add explicit Zhipu/GLM API key validation through the read-only /models endpoint
- reuse the bearer /models validation path for OpenAI-compatible key checks and show Zhipu-specific help URLs on auth and billing errors
- add regression coverage for Zhipu validation and default base URL resolution, and update AGENTS.md and CLAUDE.md

Closes #332

## Verification
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test validate_api_key_zhipu -- --nocapture
- cargo test friendly_api_error_401_zhipu -- --nocapture
- cargo test zhipu_resolves_with_default_base_url -- --nocapture
- cargo test --lib
- cargo test --doc

## Notes
- cargo nextest run --lib could not run in this environment because cargo-nextest is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider documentation with onboarding validation details and OpenAI-compatible endpoint support notes.

* **New Features**
  * Added support for Zhipu/GLM provider.
  * Enhanced provider error handling with new error types (Auth, RateLimit, Billing, ServerError, InvalidRequest, ModelNotFound, Timeout).
  * Per-provider model override capability.
  * Token-by-token streaming support via StreamEvent.
  * New OutputFormat options (Text, Json, JsonSchema).

* **Tests**
  * Added Zhipu provider validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->