### PR TITLE
fix: AgentLoop constructors respect config streaming default

### DIFF
--- a/src/agent/loop.rs
+++ b/src/agent/loop.rs
@@ -503,6 +503,7 @@ impl AgentLoop {
         };
         let cache = Self::build_cache(&config);
         let pairing = Self::build_pairing(&config);
+        let streaming_default = config.agents.defaults.streaming;
         Self {
             config,
             session_manager: Arc::new(session_manager),
@@ -517,7 +518,7 @@ impl AgentLoop {
             shutdown_tx,
             session_locks: Arc::new(Mutex::new(HashMap::new())),
             pending_messages: Arc::new(Mutex::new(HashMap::new())),
-            streaming: AtomicBool::new(false),
+            streaming: AtomicBool::new(streaming_default),
             dry_run: AtomicBool::new(false),
             token_budget,
             tool_call_limit,
@@ -571,6 +572,7 @@ impl AgentLoop {
         };
         let cache = Self::build_cache(&config);
         let pairing = Self::build_pairing(&config);
+        let streaming_default = config.agents.defaults.streaming;
         Self {
             config,
             session_manager: Arc::new(session_manager),
@@ -585,7 +587,7 @@ impl AgentLoop {
             shutdown_tx,
             session_locks: Arc::new(Mutex::new(HashMap::new())),
             pending_messages: Arc::new(Mutex::new(HashMap::new())),
-            streaming: AtomicBool::new(false),
+            streaming: AtomicBool::new(streaming_default),
             dry_run: AtomicBool::new(false),
             token_budget,
             tool_call_limit,
@@ -3037,6 +3039,16 @@ mod tests {
         let bus = Arc::new(MessageBus::new());
         let agent = AgentLoop::new(config, session_manager, bus);
         agent.set_streaming(true);
+        assert!(agent.is_streaming());
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_streaming_respects_config() {
+        let mut config = Config::default();
+        config.agents.defaults.streaming = true;
+        let session_manager = SessionManager::new_memory();
+        let bus = Arc::new(MessageBus::new());
+        let agent = AgentLoop::new(config, session_manager, bus);
         assert!(agent.is_streaming());
     }
 


### PR DESCRIPTION
## Summary
- Both `AgentLoop::new()` and `with_context_builder()` hardcoded `streaming: AtomicBool::new(false)`, ignoring `config.agents.defaults.streaming`
- Extract the config value before the struct literal and pass it to `AtomicBool::new()`
- Adds `test_agent_loop_streaming_respects_config` test

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` clean
- [x] All 5 streaming lib tests pass
- [ ] CI green

Refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming configuration settings are now properly applied on initialization

* **Tests**
  * Added verification tests for streaming configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->