### PR TITLE
feat: interactive approval prompts, streaming parity, safer defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Project-level guidance for coding agents working in this repository.
 - Extra binary: `benchmark` (`src/bin/benchmark.rs`)
 - Benchmarks: `benches/message_bus.rs`
 - Integration tests: `tests/integration.rs`
+- Agent coding benchmark fixture: `test-coding/` with intentionally buggy Python code and stdlib verification tests
+- Pristine agent comparison fixture: `test-coding-pristine/` preserves the original failing state for repeatable head-to-head runs
 - Codebase: ~106,000+ lines of Rust
 - Channels: 10 (Telegram, Slack, Discord, WhatsApp, WhatsApp Web, WhatsApp Cloud, Lark, Email, Webhook, Serial)
 - Runtimes: 6 (Native, Docker, Apple Container, Landlock, Firejail, Bubblewrap)
@@ -29,14 +31,16 @@ Project-level guidance for coding agents working in this repository.
 - Cron scheduling hardening: dispatch timeout + exponential error backoff + one-shot delete-after-run only on success
 - Model switching: Telegram `/model` supports per-chat overrides (in-memory + long-term)
 - Persona switching: `/persona` command with presets and custom text, LTM persistence per chat
-- CLI interactive mode: rustyline-backed slash commands with tab completion, persisted REPL history, `/model` and `/persona` overrides, `/tools`, `/template`, and `/clear`
+- CLI interactive mode: TTY-gated local slash commands with rustyline tab completion when available, persisted REPL history, inline tool approval prompts, session-scoped `/trust` override for local use, `/model` and `/persona` overrides, `/tools`, `/template`, and `/clear`
 - Memory injection: per-message query-matched injection via shared LTM on `AgentLoop` (startup static injection removed)
 - Tool execution convergence: agent loop and MCP server both route through `kernel::execute_tool()` (shared safety scan + taint checks + single metrics recording)
 - Tool composition: natural language tool creation with `{{param}}` template interpolation
 - Filesystem hardening: filesystem write/edit tools now create parent directories one component at a time inside the workspace and use secure no-follow writes; mount validation rejects Unix regular-file mounts with multiple hard links in both blocked-path and allowlist flows
+- Safer default execution posture: fresh configs now start in `agent_mode = "assistant"` with approvals enabled under the `require_for_dangerous` policy
 - Gateway startup guard: degrade after N crashes to prevent crash loops
 - Loop guard: SHA256 tool-call repetition detection with warn + circuit-breaker stop
 - Tool execution hardening: per-tool-call timeout + panic capture in both `process_message` and `process_message_streaming` tool `join_all` paths
+- Streaming tool parity: `process_message_streaming()` now mirrors non-streaming hook callbacks, usage-metric accounting, success/failure logging, thinking/response feedback, and malformed tool-argument parse preservation
 - Context trimming: normal/emergency/critical compaction tiers (70%/90%/95%)
 - Session repair: auto-fixes orphan tool results, empty/duplicate messages, alternation issues
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
@@ -45,7 +49,7 @@ Project-level guidance for coding agents working in this repository.
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
 - Uninstall CLI: `zeptoclaw uninstall` removes `~/.zeptoclaw`; `--remove-binary` deletes direct installs in `~/.local/bin` or `/usr/local/bin` and defers Homebrew/Cargo binaries to their package managers
 - Process exit codes: explicit `main` mapping for success (0) and error (1); uncaught panic/crash remains Rust default (101)
-- Tests: default build runs 3106 lib (3100 passed, 6 ignored) + 92 main + 24 cli_smoke + 13 e2e + 70 integration + 127 doc (27 ignored); optional features such as `whatsapp-web` add feature-gated coverage
+- Tests: current local build runs 3156 lib (3149 passed, 1 failed, 6 ignored) + 92 main + 24 cli_smoke + 13 e2e + 70 integration + 127 doc (27 ignored); optional features such as `whatsapp-web` add feature-gated coverage
 
 ## Task Tracking Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Ultra-lightweight personal AI assistant. The best of OpenClaw's integrations, NanoClaw's security, and PicoClaw's minimalism — without their tradeoffs.
 
+Fresh configs default to `assistant` mode with dangerous tool approvals enabled.
+
 ## Quick Reference
 
 ```bash
@@ -17,6 +19,12 @@ cargo build --release --features mqtt
 # Run tests (use nextest to avoid OOM kills on low-RAM machines)
 cargo nextest run --lib
 
+# Run the agent-comparison coding fixture
+python3 -m unittest test-coding/test_calculator.py -v
+
+# Run the pristine failing benchmark copy
+python3 -m unittest test-coding-pristine/test_calculator.py -v
+
 # Lint
 cargo clippy -- -D warnings
 
@@ -24,7 +32,7 @@ cargo clippy -- -D warnings
 cargo fmt
 
 # Test counts (cargo test)
-# default build: lib 3106 total (3100 passed, 6 ignored), main 92, cli_smoke 24, e2e 13, integration 70, doc 127 passed (27 ignored); optional features such as whatsapp-web add feature-gated coverage
+# current local build: lib 3156 total (3149 passed, 1 failed, 6 ignored), main 92, cli_smoke 24, e2e 13, integration 70, doc 127 passed (27 ignored); optional features such as whatsapp-web add feature-gated coverage
 
 # Version
 ./target/release/zeptoclaw --version
@@ -47,8 +55,13 @@ cargo fmt
 /template                # List available templates
 /history                 # Show history command hints
 /memory                  # Show memory command hints
+/trust                   # Show trusted local-session status
+/trust on                # Bypass approval prompts for this local interactive session
+/trust off               # Turn trusted local-session bypass back off
 /clear                   # Clear conversation
 /quit                    # Exit
+
+Interactive approval prompts and `/trust` are only active when both stdin and stdout are real TTYs.
 
 # Run gateway (Telegram bot)
 ./target/release/zeptoclaw gateway
@@ -323,7 +336,7 @@ src/
 ├── routines/       # Event/webhook/cron triggered automations
 ├── safety/         # Prompt injection detection, secret leak scanning, policy engine, chain alerting
 ├── security/       # Shell blocklist, path validation, mount policy, secret encryption
-│   ├── agent_mode.rs # Agent modes (Observer, Assistant, Autonomous) — category-based tool access
+│   ├── agent_mode.rs # Agent modes (Observer, Assistant, Autonomous) — defaults to Assistant for safer fresh configs
 │   └── encryption.rs # XChaCha20-Poly1305 + Argon2id secret encryption at rest
 ├── session/        # Session, message persistence, conversation history
 ├── tunnel/         # Tunnel providers (Cloudflare, ngrok, Tailscale)
@@ -370,7 +383,7 @@ src/
 │   ├── plugin.rs      # Plugin tool adapter (PluginTool)
 │   ├── skills_install.rs # Skill installation tool
 │   ├── skills_search.rs  # Skill discovery/search tool
-│   ├── approval.rs    # Tool approval gate (ApprovalGate)
+│   ├── approval.rs    # Tool approval gate (ApprovalGate) — defaults to enabled + require_for_dangerous
 │   ├── r8r.rs         # R8r workflow integration
 │   ├── reminder.rs    # Persistent reminders (add/complete/snooze/overdue) with cron delivery
 │   └── mcp/           # MCP (Model Context Protocol) client tools
@@ -417,6 +430,16 @@ panel/
 ├── index.html
 ├── package.json
 └── vite.config.ts
+
+test-coding/
+├── calculator.py       # Intentionally buggy coding benchmark fixture
+├── test_calculator.py  # Stdlib unittest verification for the fixture
+└── README.md           # Prompt and verification command for agent comparisons
+
+test-coding-pristine/
+├── calculator.py       # Original buggy benchmark kept unchanged for fresh comparisons
+├── test_calculator.py  # Stdlib unittest verification for the pristine fixture
+└── README.md           # Prompt and reset guidance for repeatable head-to-head runs
 ```
 
 ## Key Modules
@@ -517,6 +540,7 @@ Message input channels via `Channel` trait:
 
 ### Agent (`src/agent/`)
 - `AgentLoop` - Core message processing loop with tool execution + pre-compaction memory flush + per-message LTM memory injection override
+- `process_message_streaming()` now mirrors the non-streaming tool loop for hook callbacks, usage metrics, success/failure logging, feedback phases, and malformed tool-argument parse preservation
 - `ContextBuilder` - System prompt and conversation context builder + optional per-message memory override API
 - `TokenBudget` - Atomic per-session token budget tracker (lock-free via `AtomicU64`)
 - `ContextMonitor` - Token estimation (`words * 1.3 + 4/msg`), threshold-based compaction triggers

--- a/src/agent/loop.rs
+++ b/src/agent/loop.rs
@@ -4,6 +4,8 @@
 //! calls LLM providers, and executes tools.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -21,7 +23,7 @@ use crate::health::UsageMetrics;
 use crate::providers::{ChatOptions, LLMProvider, LLMToolCall};
 use crate::safety::SafetyLayer;
 use crate::session::{Message, Role, SessionManager, ToolCall};
-use crate::tools::approval::ApprovalGate;
+use crate::tools::approval::{ApprovalGate, ApprovalRequest, ApprovalResponse};
 use crate::tools::{Tool, ToolCategory, ToolContext, ToolRegistry};
 use crate::utils::metrics::MetricsCollector;
 
@@ -39,6 +41,59 @@ Be selective: only save what would be useful in future conversations.";
 
 /// Maximum wall-clock time (in seconds) allowed for the memory flush LLM turn.
 const MEMORY_FLUSH_TIMEOUT_SECS: u64 = 10;
+
+const INTERACTIVE_CLI_METADATA_KEY: &str = "interactive_cli";
+const TRUSTED_LOCAL_SESSION_METADATA_KEY: &str = "trusted_local_session";
+
+type ApprovalFuture = Pin<Box<dyn Future<Output = ApprovalResponse> + Send>>;
+type ApprovalHandler = Arc<dyn Fn(ApprovalRequest) -> ApprovalFuture + Send + Sync>;
+
+fn is_trusted_local_session(msg: &InboundMessage) -> bool {
+    msg.channel == "cli"
+        && msg
+            .metadata
+            .get(INTERACTIVE_CLI_METADATA_KEY)
+            .is_some_and(|value| value == "true")
+        && msg
+            .metadata
+            .get(TRUSTED_LOCAL_SESSION_METADATA_KEY)
+            .is_some_and(|value| value == "true")
+        && msg
+            .metadata
+            .get("is_batch")
+            .is_none_or(|value| value != "true")
+}
+
+async fn resolve_tool_approval(
+    gate: &ApprovalGate,
+    approval_handler: Option<&ApprovalHandler>,
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> Option<String> {
+    if !gate.requires_approval(tool_name) {
+        return None;
+    }
+
+    if let Some(handler) = approval_handler {
+        match handler(gate.create_request(tool_name, args)).await {
+            ApprovalResponse::Approved => None,
+            ApprovalResponse::Denied(reason) => Some(format!(
+                "Tool '{}' was denied by user approval. {}",
+                tool_name, reason
+            )),
+            ApprovalResponse::TimedOut => Some(format!(
+                "Tool '{}' approval timed out and was not executed.",
+                tool_name
+            )),
+        }
+    } else {
+        let prompt = gate.format_approval_request(tool_name, args);
+        Some(format!(
+            "Tool '{}' requires user approval and was not executed. {}",
+            tool_name, prompt
+        ))
+    }
+}
 
 /// Returns `true` if any tool in the batch may cause ordering-sensitive side effects
 /// (filesystem writes, shell commands) and the batch should be executed sequentially
@@ -406,6 +461,8 @@ pub struct AgentLoop {
     tool_call_limit: ToolCallLimitTracker,
     /// Tool approval gate for policy-based tool gating.
     approval_gate: Arc<ApprovalGate>,
+    /// Optional handler used by interactive frontends to resolve approval prompts inline.
+    approval_handler: Arc<RwLock<Option<ApprovalHandler>>>,
     /// Agent mode for category-based tool enforcement.
     agent_mode: crate::security::AgentMode,
     /// Optional safety layer for tool output sanitization.
@@ -522,6 +579,7 @@ impl AgentLoop {
             token_budget,
             tool_call_limit,
             approval_gate,
+            approval_handler: Arc::new(RwLock::new(None)),
             agent_mode,
             safety_layer,
             context_monitor,
@@ -590,6 +648,7 @@ impl AgentLoop {
             token_budget,
             tool_call_limit,
             approval_gate,
+            approval_handler: Arc::new(RwLock::new(None)),
             agent_mode,
             safety_layer,
             context_monitor,
@@ -732,6 +791,17 @@ impl AgentLoop {
     pub async fn register_tool(&self, tool: Box<dyn Tool>) {
         let mut tools = self.tools.write().await;
         tools.register(tool);
+    }
+
+    /// Install an approval handler used to resolve approval requests inline.
+    pub async fn set_approval_handler<F, Fut>(&self, handler: F)
+    where
+        F: Fn(ApprovalRequest) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ApprovalResponse> + Send + 'static,
+    {
+        let wrapped: ApprovalHandler = Arc::new(move |request| handler(request).boxed());
+        let mut slot = self.approval_handler.write().await;
+        *slot = Some(wrapped);
     }
 
     /// Merge all tools from a kernel ToolRegistry and register MCP clients.
@@ -1097,6 +1167,7 @@ impl AgentLoop {
                 .with_batch(msg.metadata.get("is_batch").is_some_and(|v| v == "true"));
 
             let approval_gate = Arc::clone(&self.approval_gate);
+            let approval_handler = self.approval_handler.read().await.clone();
             let safety_layer = self.safety_layer.clone();
             let taint_engine = self.taint.clone();
             let hook_engine = Arc::new(
@@ -1120,9 +1191,15 @@ impl AgentLoop {
             let event_bus_clone = self.event_bus.clone();
             let is_dry_run = self.dry_run.load(Ordering::SeqCst);
             let current_agent_mode = self.agent_mode;
+            let trusted_local_session = is_trusted_local_session(msg);
 
-            let run_sequential =
-                needs_sequential_execution(&self.tools, &response.tool_calls).await;
+            let run_sequential = (!trusted_local_session
+                && approval_handler.is_some()
+                && response
+                    .tool_calls
+                    .iter()
+                    .any(|tool_call| approval_gate.requires_approval(&tool_call.name)))
+                || needs_sequential_execution(&self.tools, &response.tool_calls).await;
             let tool_timeout_secs = if self.config.agents.defaults.tool_timeout_secs > 0 {
                 self.config.agents.defaults.tool_timeout_secs
             } else {
@@ -1145,6 +1222,7 @@ impl AgentLoop {
                     let usage_metrics = usage_metrics.clone();
                     let metrics_collector = Arc::clone(&metrics_collector);
                     let gate = Arc::clone(&approval_gate);
+                    let approval_handler = approval_handler.clone();
                     let hooks = Arc::clone(&hook_engine);
                     let safety = safety_layer.clone();
                     let taint = taint_engine.clone();
@@ -1195,7 +1273,9 @@ impl AgentLoop {
                                         ), false);
                                     }
                                     crate::security::CategoryPermission::RequiresApproval => {
-                                        if !gate.requires_approval(&name) {
+                                        if trusted_local_session {
+                                            info!(tool = %name, mode = %agent_mode, category = ?tool_category, "Trusted local session bypassed approval-gated tool");
+                                        } else if !gate.requires_approval(&name) {
                                             info!(tool = %name, mode = %agent_mode, category = ?tool_category, "Tool requires approval per agent mode");
                                             return (id, format!(
                                                 "Tool '{}' requires approval in {} mode (category: {}). Not executed.",
@@ -1210,10 +1290,18 @@ impl AgentLoop {
                         }
 
                         // Check approval gate before executing
-                        if gate.requires_approval(&name) {
-                            let prompt = gate.format_approval_request(&name, &args);
-                            info!(tool = %name, "Tool requires approval, blocking execution");
-                            return (id, format!("Tool '{}' requires user approval and was not executed. {}", name, prompt), false);
+                        if !trusted_local_session {
+                            if let Some(message) = resolve_tool_approval(
+                                &gate,
+                                approval_handler.as_ref(),
+                                &name,
+                                &args,
+                            )
+                            .await
+                            {
+                                info!(tool = %name, "Tool requires approval, blocking execution");
+                                return (id, message, false);
+                            }
                         }
 
                         // Dry-run mode: describe what would happen without executing
@@ -1590,6 +1678,10 @@ impl AgentLoop {
             .resolve_provider_for_message(msg)
             .await
             .ok_or_else(|| ZeptoError::Provider("No provider configured".into()))?;
+        let usage_metrics = {
+            let metrics = self.usage_metrics.read().await;
+            metrics.clone()
+        };
         let metrics_collector = Arc::clone(&self.metrics_collector);
 
         let mut session = self.session_manager.get_or_create(&msg.session_key).await?;
@@ -1658,11 +1750,31 @@ impl AgentLoop {
             )));
         }
 
+        if let Some(tx) = self.tool_feedback_tx.read().await.as_ref() {
+            let _ = tx.send(ToolFeedback {
+                tool_name: String::new(),
+                phase: ToolFeedbackPhase::Thinking,
+                args_json: None,
+            });
+        }
+
         // First call: non-streaming to see if there are tool calls
         let mut response = provider
             .chat(messages, tool_definitions, model, options.clone())
             .await?;
+        if let Some(tx) = self.tool_feedback_tx.read().await.as_ref() {
+            let _ = tx.send(ToolFeedback {
+                tool_name: String::new(),
+                phase: ToolFeedbackPhase::ThinkingDone,
+                args_json: None,
+            });
+        }
+        if let (Some(metrics), Some(usage)) = (usage_metrics.as_ref(), response.usage.as_ref()) {
+            metrics.record_tokens(usage.prompt_tokens as u64, usage.completion_tokens as u64);
+        }
         if let Some(usage) = response.usage.as_ref() {
+            metrics_collector
+                .record_tokens(usage.prompt_tokens as u64, usage.completion_tokens as u64);
             self.token_budget
                 .record(usage.prompt_tokens as u64, usage.completion_tokens as u64);
         }
@@ -1684,6 +1796,7 @@ impl AgentLoop {
 
         while response.has_tool_calls() && iteration < max_iterations {
             iteration += 1;
+            debug!("Tool iteration {} of {}", iteration, max_iterations);
 
             // Enforce tool call limit BEFORE adding assistant message to session
             // (streaming path). Same rationale as non-streaming: avoids orphaned
@@ -1706,6 +1819,10 @@ impl AgentLoop {
                     );
                     response.tool_calls.truncate(allowed);
                 }
+            }
+
+            if let Some(metrics) = usage_metrics.as_ref() {
+                metrics.record_tool_calls(response.tool_calls.len() as u64);
             }
 
             // Add assistant message with tool calls (post-truncation).
@@ -1731,8 +1848,13 @@ impl AgentLoop {
                 .with_batch(msg.metadata.get("is_batch").is_some_and(|v| v == "true"));
 
             let approval_gate = Arc::clone(&self.approval_gate);
+            let approval_handler = self.approval_handler.read().await.clone();
             let safety_layer_stream = self.safety_layer.clone();
             let taint_engine_stream = self.taint.clone();
+            let hook_engine = Arc::new(
+                crate::hooks::HookEngine::new(self.config.hooks.clone())
+                    .with_bus(Arc::clone(&self.bus)),
+            );
 
             // Compute dynamic tool result budget based on remaining context space
             let current_tokens_stream = ContextMonitor::estimate_tokens(&session.messages);
@@ -1750,9 +1872,15 @@ impl AgentLoop {
             let event_bus_clone_stream = self.event_bus.clone();
             let is_dry_run_stream = self.dry_run.load(Ordering::SeqCst);
             let current_agent_mode_stream = self.agent_mode;
+            let trusted_local_session = is_trusted_local_session(msg);
 
-            let run_sequential =
-                needs_sequential_execution(&self.tools, &response.tool_calls).await;
+            let run_sequential = (!trusted_local_session
+                && approval_handler.is_some()
+                && response
+                    .tool_calls
+                    .iter()
+                    .any(|tool_call| approval_gate.requires_approval(&tool_call.name)))
+                || needs_sequential_execution(&self.tools, &response.tool_calls).await;
             let tool_timeout_secs = if self.config.agents.defaults.tool_timeout_secs > 0 {
                 self.config.agents.defaults.tool_timeout_secs
             } else {
@@ -1772,8 +1900,11 @@ impl AgentLoop {
                     let name = tool_call.name.clone();
                     let id = tool_call.id.clone();
                     let raw_args = tool_call.arguments.clone();
+                    let usage_metrics = usage_metrics.clone();
                     let metrics_collector = Arc::clone(&metrics_collector);
                     let gate = Arc::clone(&approval_gate);
+                    let approval_handler = approval_handler.clone();
+                    let hooks = Arc::clone(&hook_engine);
                     let safety = safety_layer_stream.clone();
                     let taint = taint_engine_stream.clone();
                     let budget = result_budget_stream;
@@ -1786,8 +1917,21 @@ impl AgentLoop {
                     let inbound_meta = inbound_metadata_stream.clone();
 
                     async move {
-                        let args: serde_json::Value = serde_json::from_str(&raw_args)
-                            .unwrap_or_else(|_| serde_json::json!({}));
+                        let args: serde_json::Value = match serde_json::from_str(&raw_args) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!(tool = %name, error = %e, "Invalid JSON in tool arguments");
+                                serde_json::json!({"_parse_error": format!("Invalid arguments JSON: {}", e)})
+                            }
+                        };
+
+                        let channel_name = ctx.channel.as_deref().unwrap_or("cli");
+                        let chat_id = ctx.chat_id.as_deref().unwrap_or(channel_name);
+                        if let crate::hooks::HookResult::Block(msg) =
+                            hooks.before_tool(&name, &args, channel_name, chat_id)
+                        {
+                            return (id, format!("Tool '{}' blocked by hook: {}", name, msg), false);
+                        }
 
                         // Agent mode enforcement — same fail-closed logic as non-streaming path.
                         {
@@ -1804,7 +1948,9 @@ impl AgentLoop {
                                         ), false);
                                     }
                                     crate::security::CategoryPermission::RequiresApproval => {
-                                        if !gate.requires_approval(&name) {
+                                        if trusted_local_session {
+                                            info!(tool = %name, mode = %agent_mode, category = ?tool_category, "Trusted local session bypassed approval-gated tool");
+                                        } else if !gate.requires_approval(&name) {
                                             info!(tool = %name, mode = %agent_mode, category = ?tool_category, "Tool requires approval per agent mode");
                                             return (id, format!(
                                                 "Tool '{}' requires approval in {} mode (category: {}). Not executed.",
@@ -1818,17 +1964,18 @@ impl AgentLoop {
                         }
 
                         // Check approval gate before executing
-                        if gate.requires_approval(&name) {
-                            let prompt = gate.format_approval_request(&name, &args);
-                            info!(tool = %name, "Tool requires approval, blocking execution");
-                            return (
-                                id,
-                                format!(
-                                    "Tool '{}' requires user approval and was not executed. {}",
-                                    name, prompt
-                                ),
-                                false,
-                            );
+                        if !trusted_local_session {
+                            if let Some(message) = resolve_tool_approval(
+                                &gate,
+                                approval_handler.as_ref(),
+                                &name,
+                                &args,
+                            )
+                            .await
+                            {
+                                info!(tool = %name, "Tool requires approval, blocking execution");
+                                return (id, message, false);
+                            }
                         }
 
                         // Dry-run mode: describe what would happen without executing
@@ -1882,6 +2029,8 @@ impl AgentLoop {
                             }
                         };
                         let pause = tool_output.as_ref().is_some_and(|o| o.pause_for_input);
+                        let elapsed = tool_start.elapsed();
+                        let latency_ms = elapsed.as_millis() as u64;
                         if let Some(output) = tool_output {
                             // Send to user if tool opted in
                             if let Some(ref user_msg) = output.for_user {
@@ -1899,10 +2048,10 @@ impl AgentLoop {
                                 let _ = bus_for_tools.publish_outbound(outbound).await;
                             }
                         }
-                        // Send tool done/failed feedback
-                        let latency_ms = tool_start.elapsed().as_millis() as u64;
-                        if let Some(tx) = tool_feedback_tx.read().await.as_ref() {
-                            if success {
+                        if success {
+                            debug!(tool = %name, latency_ms = latency_ms, "Tool executed successfully");
+                            hooks.after_tool(&name, &result, elapsed, channel_name, chat_id);
+                            if let Some(tx) = tool_feedback_tx.read().await.as_ref() {
                                 let _ = tx.send(ToolFeedback {
                                     tool_name: name.clone(),
                                     phase: ToolFeedbackPhase::Done {
@@ -1910,7 +2059,21 @@ impl AgentLoop {
                                     },
                                     args_json: Some(raw_args.clone()),
                                 });
-                            } else {
+                            }
+                            #[cfg(feature = "panel")]
+                            if let Some(bus) = &event_bus {
+                                bus.send(crate::api::events::PanelEvent::ToolDone {
+                                    tool: name.clone(),
+                                    duration_ms: latency_ms,
+                                });
+                            }
+                        } else {
+                            error!(tool = %name, latency_ms = latency_ms, error = %result, "Tool execution failed");
+                            hooks.on_error(&name, &result, channel_name, chat_id);
+                            if let Some(metrics) = usage_metrics.as_ref() {
+                                metrics.record_error();
+                            }
+                            if let Some(tx) = tool_feedback_tx.read().await.as_ref() {
                                 let _ = tx.send(ToolFeedback {
                                     tool_name: name.clone(),
                                     phase: ToolFeedbackPhase::Failed {
@@ -1920,15 +2083,8 @@ impl AgentLoop {
                                     args_json: Some(raw_args.clone()),
                                 });
                             }
-                        }
-                        #[cfg(feature = "panel")]
-                        if let Some(bus) = &event_bus {
-                            if success {
-                                bus.send(crate::api::events::PanelEvent::ToolDone {
-                                    tool: name.clone(),
-                                    duration_ms: latency_ms,
-                                });
-                            } else {
+                            #[cfg(feature = "panel")]
+                            if let Some(bus) = &event_bus {
                                 bus.send(crate::api::events::PanelEvent::ToolFailed {
                                     tool: name.clone(),
                                     error: result.clone(),
@@ -2034,15 +2190,42 @@ impl AgentLoop {
                 .filter(|m| !(m.role == Role::User && m.content.is_empty()))
                 .collect();
 
+            if let Some(tx) = self.tool_feedback_tx.read().await.as_ref() {
+                let _ = tx.send(ToolFeedback {
+                    tool_name: String::new(),
+                    phase: ToolFeedbackPhase::Thinking,
+                    args_json: None,
+                });
+            }
+
             response = provider
                 .chat(messages, tool_definitions, model, options.clone())
                 .await?;
+            if let Some(tx) = self.tool_feedback_tx.read().await.as_ref() {
+                let _ = tx.send(ToolFeedback {
+                    tool_name: String::new(),
+                    phase: ToolFeedbackPhase::ThinkingDone,
+                    args_json: None,
+                });
+            }
+            if let (Some(metrics), Some(usage)) = (usage_metrics.as_ref(), response.usage.as_ref())
+            {
+                metrics.record_tokens(usage.prompt_tokens as u64, usage.completion_tokens as u64);
+            }
             if let Some(usage) = response.usage.as_ref() {
                 metrics_collector
                     .record_tokens(usage.prompt_tokens as u64, usage.completion_tokens as u64);
                 self.token_budget
                     .record(usage.prompt_tokens as u64, usage.completion_tokens as u64);
             }
+        }
+
+        if let Some(tx) = self.tool_feedback_tx.read().await.as_ref() {
+            let _ = tx.send(ToolFeedback {
+                tool_name: String::new(),
+                phase: ToolFeedbackPhase::ResponseReady,
+                args_json: None,
+            });
         }
 
         // Final call: if no more tool calls, use streaming
@@ -2076,6 +2259,7 @@ impl AgentLoop {
             let (out_tx, out_rx) = tokio::sync::mpsc::channel::<StreamEvent>(32);
             let session_manager = Arc::clone(&self.session_manager);
             let session_clone = session.clone();
+            let usage_metrics = usage_metrics.clone();
             let metrics_collector = Arc::clone(&metrics_collector);
 
             tokio::spawn(async move {
@@ -2086,6 +2270,12 @@ impl AgentLoop {
                     match &event {
                         StreamEvent::Done { content, usage } => {
                             if let Some(usage) = usage.as_ref() {
+                                if let Some(metrics) = usage_metrics.as_ref() {
+                                    metrics.record_tokens(
+                                        usage.prompt_tokens as u64,
+                                        usage.completion_tokens as u64,
+                                    );
+                                }
                                 metrics_collector.record_tokens(
                                     usage.prompt_tokens as u64,
                                     usage.completion_tokens as u64,
@@ -2681,13 +2871,20 @@ impl AgentLoop {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::providers::{LLMResponse, ToolDefinition};
+    use crate::hooks::{HookAction, HookRule};
+    use crate::providers::{LLMResponse, StreamEvent, ToolDefinition, Usage};
     use async_trait::async_trait;
 
     #[derive(Debug)]
     struct TestProvider {
         name: &'static str,
         model: &'static str,
+    }
+
+    struct ToolThenTextProvider {
+        calls: std::sync::Mutex<u8>,
+        tool_name: &'static str,
+        tool_args: &'static str,
     }
 
     #[async_trait]
@@ -2709,6 +2906,54 @@ mod tests {
         ) -> Result<LLMResponse> {
             Ok(LLMResponse::text("ok"))
         }
+    }
+
+    #[async_trait]
+    impl LLMProvider for ToolThenTextProvider {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        async fn chat(
+            &self,
+            _messages: Vec<Message>,
+            _tools: Vec<ToolDefinition>,
+            _model: Option<&str>,
+            _options: ChatOptions,
+        ) -> Result<LLMResponse> {
+            let mut calls = self.calls.lock().expect("provider call counter poisoned");
+            *calls += 1;
+            if *calls == 1 {
+                Ok(LLMResponse::with_tools(
+                    "",
+                    vec![LLMToolCall::new("call_1", self.tool_name, self.tool_args)],
+                )
+                .with_usage(Usage::new(10, 1)))
+            } else {
+                let call_num = *calls as u32;
+                Ok(LLMResponse::text("done").with_usage(Usage::new(10 + call_num, call_num)))
+            }
+        }
+    }
+
+    async fn collect_stream_done(
+        mut rx: tokio::sync::mpsc::Receiver<StreamEvent>,
+    ) -> (String, Option<Usage>) {
+        while let Some(event) = rx.recv().await {
+            match event {
+                StreamEvent::Done { content, usage } => return (content, usage),
+                StreamEvent::Delta(_) => {}
+                StreamEvent::ToolCalls(tool_calls) => {
+                    panic!("unexpected tool calls in final stream: {:?}", tool_calls)
+                }
+                StreamEvent::Error(err) => panic!("unexpected stream error: {err}"),
+            }
+        }
+        panic!("stream ended without a Done event");
     }
 
     #[tokio::test]
@@ -2835,6 +3080,187 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ZeptoError::Provider(_)));
         assert!(err.to_string().contains("No provider configured"));
+    }
+
+    #[tokio::test]
+    async fn test_process_message_approval_handler_allows_tool_execution() {
+        let config = Config::default();
+        let session_manager = SessionManager::new_memory();
+        let bus = Arc::new(MessageBus::new());
+        let agent = AgentLoop::new(config, session_manager, bus);
+
+        agent
+            .set_provider(Box::new(ToolThenTextProvider {
+                calls: std::sync::Mutex::new(0),
+                tool_name: "shell",
+                tool_args: "{}",
+            }))
+            .await;
+        agent
+            .register_tool(Box::new(StubTool {
+                name: "shell",
+                category: ToolCategory::Shell,
+            }))
+            .await;
+        agent
+            .set_approval_handler(|_| async { ApprovalResponse::Approved })
+            .await;
+
+        let msg = InboundMessage::new("cli", "user", "cli", "run a tool")
+            .with_metadata(INTERACTIVE_CLI_METADATA_KEY, "true");
+        let result = agent
+            .process_message(&msg)
+            .await
+            .expect("message should succeed");
+
+        assert_eq!(result, "done");
+    }
+
+    #[tokio::test]
+    async fn test_process_message_trusted_local_session_bypasses_approval() {
+        let config = Config::default();
+        let session_manager = SessionManager::new_memory();
+        let bus = Arc::new(MessageBus::new());
+        let agent = AgentLoop::new(config, session_manager, bus);
+
+        agent
+            .set_provider(Box::new(ToolThenTextProvider {
+                calls: std::sync::Mutex::new(0),
+                tool_name: "shell",
+                tool_args: "{}",
+            }))
+            .await;
+        agent
+            .register_tool(Box::new(StubTool {
+                name: "shell",
+                category: ToolCategory::Shell,
+            }))
+            .await;
+
+        let msg = InboundMessage::new("cli", "user", "cli", "run a tool")
+            .with_metadata(INTERACTIVE_CLI_METADATA_KEY, "true")
+            .with_metadata(TRUSTED_LOCAL_SESSION_METADATA_KEY, "true");
+        let result = agent
+            .process_message(&msg)
+            .await
+            .expect("message should succeed");
+
+        assert_eq!(result, "done");
+    }
+
+    #[test]
+    fn test_trusted_local_session_requires_cli_channel() {
+        let msg = InboundMessage::new("telegram", "user", "chat", "hello")
+            .with_metadata(INTERACTIVE_CLI_METADATA_KEY, "true")
+            .with_metadata(TRUSTED_LOCAL_SESSION_METADATA_KEY, "true");
+
+        assert!(!is_trusted_local_session(&msg));
+    }
+
+    #[tokio::test]
+    async fn test_process_message_streaming_respects_before_tool_hooks() {
+        let mut config = Config::default();
+        config.hooks.enabled = true;
+        config.hooks.before_tool.push(HookRule {
+            action: HookAction::Block,
+            tools: vec!["read_file".to_string()],
+            channels: vec![],
+            level: None,
+            message: Some("hook blocked".to_string()),
+            channel: None,
+            chat_id: None,
+        });
+
+        let session_manager = SessionManager::new_memory();
+        let bus = Arc::new(MessageBus::new());
+        let agent = AgentLoop::new(config, session_manager, bus);
+        let tool_calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        agent
+            .set_provider(Box::new(ToolThenTextProvider {
+                calls: std::sync::Mutex::new(0),
+                tool_name: "read_file",
+                tool_args: "{}",
+            }))
+            .await;
+        agent
+            .register_tool(Box::new(InstrumentedTool {
+                name: "read_file",
+                category: ToolCategory::FilesystemRead,
+                calls: Arc::clone(&tool_calls),
+                fail: false,
+                last_args: None,
+            }))
+            .await;
+
+        let msg = InboundMessage::new("cli", "user", "cli", "run a tool");
+        let stream = agent
+            .process_message_streaming(&msg)
+            .await
+            .expect("streaming message should succeed");
+        let (content, _) = collect_stream_done(stream).await;
+
+        assert_eq!(content, "done");
+        assert_eq!(tool_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn test_process_message_streaming_records_usage_metrics_and_parse_errors() {
+        let config = Config::default();
+        let session_manager = SessionManager::new_memory();
+        let bus = Arc::new(MessageBus::new());
+        let agent = AgentLoop::new(config, session_manager, bus);
+        let metrics = Arc::new(UsageMetrics::new());
+        let tool_calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let last_args = Arc::new(std::sync::Mutex::new(None));
+
+        agent.set_usage_metrics(Arc::clone(&metrics)).await;
+        agent
+            .set_provider(Box::new(ToolThenTextProvider {
+                calls: std::sync::Mutex::new(0),
+                tool_name: "read_file",
+                tool_args: "{bad json",
+            }))
+            .await;
+        agent
+            .register_tool(Box::new(InstrumentedTool {
+                name: "read_file",
+                category: ToolCategory::FilesystemRead,
+                calls: Arc::clone(&tool_calls),
+                fail: true,
+                last_args: Some(Arc::clone(&last_args)),
+            }))
+            .await;
+
+        let msg = InboundMessage::new("cli", "user", "cli", "run a tool");
+        let stream = agent
+            .process_message_streaming(&msg)
+            .await
+            .expect("streaming message should succeed");
+        let (content, usage) = collect_stream_done(stream).await;
+        let observed_args = last_args
+            .lock()
+            .expect("args mutex poisoned")
+            .clone()
+            .expect("tool should receive arguments");
+        let usage = usage.expect("stream should include usage");
+
+        assert_eq!(content, "done");
+        assert_eq!(usage.prompt_tokens, 13);
+        assert_eq!(usage.completion_tokens, 3);
+        assert_eq!(usage.total_tokens, 16);
+        assert_eq!(tool_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.tool_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.errors.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.input_tokens.load(Ordering::Relaxed), 35);
+        assert_eq!(metrics.output_tokens.load(Ordering::Relaxed), 6);
+        assert!(
+            observed_args
+                .get("_parse_error")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|msg| msg.contains("Invalid arguments JSON")),
+            "streaming path should preserve parse errors for downstream policy and tooling"
+        );
     }
 
     #[tokio::test]
@@ -3386,6 +3812,46 @@ mod tests {
             _ctx: &ToolContext,
         ) -> std::result::Result<crate::tools::ToolOutput, crate::error::ZeptoError> {
             Ok(crate::tools::ToolOutput::llm_only("ok"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct InstrumentedTool {
+        name: &'static str,
+        category: ToolCategory,
+        calls: Arc<std::sync::atomic::AtomicU64>,
+        fail: bool,
+        last_args: Option<Arc<std::sync::Mutex<Option<serde_json::Value>>>>,
+    }
+
+    #[async_trait]
+    impl Tool for InstrumentedTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn description(&self) -> &str {
+            ""
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        fn category(&self) -> ToolCategory {
+            self.category
+        }
+        async fn execute(
+            &self,
+            args: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<crate::tools::ToolOutput, crate::error::ZeptoError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if let Some(last_args) = &self.last_args {
+                *last_args.lock().expect("args mutex poisoned") = Some(args);
+            }
+            if self.fail {
+                Err(crate::error::ZeptoError::Tool("boom".into()))
+            } else {
+                Ok(crate::tools::ToolOutput::llm_only("ok"))
+            }
         }
     }
 

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,6 +1,6 @@
 //! Agent command handlers (interactive + stdin mode).
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -15,6 +15,7 @@ use zeptoclaw::health::UsageMetrics;
 use zeptoclaw::providers::{
     configured_provider_names, resolve_runtime_provider, RUNTIME_SUPPORTED_PROVIDERS,
 };
+use zeptoclaw::tools::approval::{ApprovalRequest, ApprovalResponse};
 
 use super::common::{create_agent, create_agent_with_template, resolve_template};
 use super::slash::SlashHelper;
@@ -22,6 +23,8 @@ use super::slash::SlashHelper;
 const CLI_CHANNEL: &str = "cli";
 const CLI_SENDER_ID: &str = "user";
 const CLI_CHAT_ID: &str = "cli";
+const INTERACTIVE_CLI_METADATA_KEY: &str = "interactive_cli";
+const TRUSTED_LOCAL_SESSION_METADATA_KEY: &str = "trusted_local_session";
 
 fn cli_inbound_message(content: &str) -> InboundMessage {
     InboundMessage::new(CLI_CHANNEL, CLI_SENDER_ID, CLI_CHAT_ID, content)
@@ -59,6 +62,54 @@ fn format_tool_list(tool_names: &[&str]) -> String {
         out.push('\n');
     }
     out.trim_end().to_string()
+}
+
+fn prompt_cli_approval(request: ApprovalRequest) -> ApprovalResponse {
+    let args_display = serde_json::to_string_pretty(&request.arguments)
+        .unwrap_or_else(|_| request.arguments.to_string());
+
+    println!();
+    println!("[Approval Required]");
+    println!("Tool: {}", request.tool_name);
+    println!("Arguments:\n{}", args_display);
+    println!();
+
+    loop {
+        print!("Approve execution? [y/N]: ");
+        let _ = io::stdout().flush();
+
+        let mut input = String::new();
+        match io::stdin().lock().read_line(&mut input) {
+            Ok(0) => {
+                return ApprovalResponse::Denied(
+                    "Approval prompt closed before a response was provided.".to_string(),
+                );
+            }
+            Ok(_) => match input.trim().to_ascii_lowercase().as_str() {
+                "y" | "yes" => return ApprovalResponse::Approved,
+                "" | "n" | "no" => {
+                    return ApprovalResponse::Denied("Execution not approved.".to_string());
+                }
+                _ => {
+                    println!("Please answer 'yes' or 'no'.");
+                }
+            },
+            Err(e) => {
+                return ApprovalResponse::Denied(format!(
+                    "Failed to read approval response: {}",
+                    e
+                ));
+            }
+        }
+    }
+}
+
+fn is_interactive_cli_terminal(stdin_terminal: bool, stdout_terminal: bool) -> bool {
+    stdin_terminal && stdout_terminal
+}
+
+fn has_interactive_cli_terminal() -> bool {
+    is_interactive_cli_terminal(io::stdin().is_terminal(), io::stdout().is_terminal())
 }
 
 /// Interactive or single-message agent mode.
@@ -249,20 +300,41 @@ pub(crate) async fn cmd_agent(
         let mut model_override: Option<(Option<String>, String)> = None; // (provider, model)
         let mut persona_override: Option<String> = None;
 
-        // Try rustyline; fall back to raw stdin if terminal is unavailable.
-        let mut rl = match Editor::new() {
-            Ok(mut editor) => {
-                editor.set_helper(Some(SlashHelper::new()));
-                // Persist history across sessions
-                let history_path =
-                    dirs::home_dir().map(|h| h.join(".zeptoclaw/state/repl_history"));
-                if let Some(ref path) = history_path {
-                    let _ = editor.load_history(path);
+        let interactive_cli = has_interactive_cli_terminal();
+        // Try rustyline for interactive terminals; fall back to raw stdin if line editing
+        // is unavailable or terminal support is limited.
+        let mut rl = if interactive_cli {
+            match Editor::new() {
+                Ok(mut editor) => {
+                    editor.set_helper(Some(SlashHelper::new()));
+                    // Persist history across sessions
+                    let history_path =
+                        dirs::home_dir().map(|h| h.join(".zeptoclaw/state/repl_history"));
+                    if let Some(ref path) = history_path {
+                        let _ = editor.load_history(path);
+                    }
+                    Some((editor, history_path))
                 }
-                Some((editor, history_path))
+                Err(_) => None,
             }
-            Err(_) => None,
+        } else {
+            None
         };
+        let mut trusted_session = false;
+
+        if interactive_cli {
+            agent
+                .set_approval_handler(|request| async move {
+                    match tokio::task::spawn_blocking(move || prompt_cli_approval(request)).await {
+                        Ok(response) => response,
+                        Err(e) => ApprovalResponse::Denied(format!(
+                            "Interactive approval prompt failed: {}",
+                            e
+                        )),
+                    }
+                })
+                .await;
+        }
 
         loop {
             let input = if let Some((ref mut editor, _)) = rl {
@@ -278,8 +350,8 @@ pub(crate) async fn cmd_agent(
                     }
                 }
             } else {
-                // Fallback: raw stdin (piped/non-TTY) — no prompt to avoid
-                // contaminating piped output.
+                // Fallback: raw stdin for non-interactive input or terminals where
+                // line editing is unavailable.
                 let mut buf = String::new();
                 match io::stdin().lock().read_line(&mut buf) {
                     Ok(0) => {
@@ -449,6 +521,36 @@ pub(crate) async fn cmd_agent(
                         }
                         continue;
                     }
+                    "trust" => {
+                        if interactive_cli {
+                            let status = if trusted_session { "ON" } else { "OFF" };
+                            println!("Trusted local session is {}.", status);
+                            if !trusted_session {
+                                println!(
+                                    "Use /trust on to bypass approval prompts for this local interactive CLI session."
+                                );
+                            }
+                        } else {
+                            println!("Trusted session override is only available in interactive CLI mode.");
+                        }
+                        continue;
+                    }
+                    "trust on" => {
+                        if interactive_cli {
+                            trusted_session = true;
+                            println!(
+                                "Trusted local session enabled for this interactive CLI session."
+                            );
+                        } else {
+                            println!("Trusted session override is only available in interactive CLI mode.");
+                        }
+                        continue;
+                    }
+                    "trust off" => {
+                        trusted_session = false;
+                        println!("Trusted local session disabled.");
+                        continue;
+                    }
                     _ => {
                         eprintln!("Unknown command: /{}", cmd);
                         eprintln!("Type /help to see available commands.");
@@ -465,6 +567,12 @@ pub(crate) async fn cmd_agent(
 
             // Process message through agent, injecting any active overrides
             let mut inbound = cli_inbound_message(input);
+            if interactive_cli {
+                inbound = inbound.with_metadata(INTERACTIVE_CLI_METADATA_KEY, "true");
+                if trusted_session {
+                    inbound = inbound.with_metadata(TRUSTED_LOCAL_SESSION_METADATA_KEY, "true");
+                }
+            }
             if let Some((ref provider, ref model)) = model_override {
                 inbound = inbound.with_metadata("model_override", model);
                 if let Some(ref p) = provider {
@@ -725,5 +833,13 @@ mod tests {
         let list =
             zeptoclaw::channels::model_switch::format_model_list(&providers, current.as_ref(), &[]);
         assert!(list.contains("gpt-5.1 GPT-5.1 (current)"));
+    }
+
+    #[test]
+    fn test_has_interactive_cli_terminal_requires_stdin_and_stdout_tty() {
+        assert!(is_interactive_cli_terminal(true, true));
+        assert!(!is_interactive_cli_terminal(true, false));
+        assert!(!is_interactive_cli_terminal(false, true));
+        assert!(!is_interactive_cli_terminal(false, false));
     }
 }

--- a/src/cli/slash.rs
+++ b/src/cli/slash.rs
@@ -59,6 +59,18 @@ pub fn builtin_commands() -> Vec<SlashCommand> {
             description: "Show available templates",
         },
         SlashCommand {
+            name: "trust",
+            description: "Show local trusted-session status",
+        },
+        SlashCommand {
+            name: "trust on",
+            description: "Bypass approvals for this interactive CLI session",
+        },
+        SlashCommand {
+            name: "trust off",
+            description: "Disable trusted-session bypass",
+        },
+        SlashCommand {
             name: "clear",
             description: "Clear conversation context",
         },
@@ -229,6 +241,7 @@ mod tests {
         assert!(help.contains("/model"));
         assert!(help.contains("/persona"));
         assert!(help.contains("/help"));
+        assert!(help.contains("/trust"));
         assert!(help.contains("/quit"));
         // Subcommands should NOT appear as top-level entries
         assert!(!help.contains("/model list"));
@@ -246,9 +259,11 @@ mod tests {
         let template = cmds.iter().find(|cmd| cmd.name == "template").unwrap();
         let history = cmds.iter().find(|cmd| cmd.name == "history").unwrap();
         let memory = cmds.iter().find(|cmd| cmd.name == "memory").unwrap();
+        let trust = cmds.iter().find(|cmd| cmd.name == "trust").unwrap();
 
         assert_eq!(template.description, "List available templates");
         assert_eq!(history.description, "Show history command hints");
         assert_eq!(memory.description, "Show memory command hints");
+        assert_eq!(trust.description, "Show local trusted-session status");
     }
 }

--- a/src/security/agent_mode.rs
+++ b/src/security/agent_mode.rs
@@ -17,17 +17,17 @@ use crate::tools::ToolCategory;
 /// Agent execution mode controlling tool permissions.
 ///
 /// Determines which tool categories are allowed, require approval, or are
-/// blocked during an agent session. The default mode is `Autonomous` for
-/// backward compatibility.
+/// blocked during an agent session. The default mode is `Assistant` so fresh
+/// configs start with approval-gated dangerous actions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AgentMode {
     /// Read-only mode. Only FilesystemRead, NetworkRead, and Memory are allowed.
     Observer,
     /// Read/write mode. Most tools allowed; Shell, Hardware, Destructive need approval.
+    #[default]
     Assistant,
     /// Full access. All tool categories are allowed without restriction.
-    #[default]
     Autonomous,
 }
 
@@ -139,7 +139,7 @@ pub struct AgentModeConfig {
 impl Default for AgentModeConfig {
     fn default() -> Self {
         Self {
-            mode: "autonomous".into(),
+            mode: "assistant".into(),
         }
     }
 }
@@ -341,8 +341,8 @@ mod tests {
     }
 
     #[test]
-    fn test_default_mode_is_autonomous() {
-        assert_eq!(AgentMode::default(), AgentMode::Autonomous);
+    fn test_default_mode_is_assistant() {
+        assert_eq!(AgentMode::default(), AgentMode::Assistant);
     }
 
     #[test]
@@ -355,13 +355,13 @@ mod tests {
     #[test]
     fn test_mode_config_defaults() {
         let cfg = AgentModeConfig::default();
-        assert_eq!(cfg.mode, "autonomous");
+        assert_eq!(cfg.mode, "assistant");
     }
 
     #[test]
     fn test_mode_config_resolve() {
         let mut cfg = AgentModeConfig::default();
-        assert_eq!(cfg.resolve(), AgentMode::Autonomous);
+        assert_eq!(cfg.resolve(), AgentMode::Assistant);
 
         cfg.mode = "observer".to_string();
         assert_eq!(cfg.resolve(), AgentMode::Observer);

--- a/src/tools/approval.rs
+++ b/src/tools/approval.rs
@@ -7,10 +7,10 @@
 //!
 //! # Policies
 //!
-//! - `AlwaysAllow` - All tools execute without approval (default)
+//! - `AlwaysAllow` - All tools execute without approval
 //! - `AlwaysRequire` - Every tool invocation requires approval
 //! - `RequireForTools` - Only named tools require approval
-//! - `RequireForDangerous` - Tools tagged as "dangerous" require approval
+//! - `RequireForDangerous` - Tools tagged as "dangerous" require approval (default)
 //!
 //! # Configuration
 //!
@@ -21,7 +21,7 @@
 //!     "approval": {
 //!         "enabled": true,
 //!         "policy": "require_for_dangerous",
-//!         "dangerous_tools": ["shell", "write_file", "edit_file"]
+//!         "dangerous_tools": ["shell", "write_file", "edit_file", "google"]
 //!     }
 //! }
 //! ```
@@ -34,8 +34,8 @@
 //! let config = ApprovalConfig::default();
 //! let gate = ApprovalGate::new(config);
 //!
-//! // Default policy is AlwaysAllow with enabled=false
-//! assert!(!gate.requires_approval("shell"));
+//! // Default policy gates dangerous tools.
+//! assert!(gate.requires_approval("shell"));
 //! ```
 
 use chrono::{DateTime, Duration, Utc};
@@ -73,13 +73,13 @@ pub enum ApprovalPolicy {
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalPolicyConfig {
     /// All tools execute without approval.
-    #[default]
     AlwaysAllow,
     /// Every tool invocation requires approval.
     AlwaysRequire,
     /// Only tools listed in `require_for` need approval.
     RequireForTools,
     /// Tools in the `dangerous_tools` list need approval.
+    #[default]
     RequireForDangerous,
 }
 
@@ -94,16 +94,18 @@ pub enum ApprovalPolicyConfig {
 ///
 /// # Defaults
 ///
-/// - `enabled`: `false`
-/// - `policy`: `AlwaysAllow`
+/// - `enabled`: `true`
+/// - `policy`: `RequireForDangerous`
 /// - `require_for`: empty
-/// - `dangerous_tools`: `["shell", "write_file", "edit_file"]`
+/// - `dangerous_tools`: `["shell", "write_file", "edit_file", "google"]`
 /// - `auto_approve_timeout_secs`: `0` (disabled)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ApprovalConfig {
-    /// Master switch. When `false`, all tools execute without approval
-    /// regardless of the policy setting.
+    /// Master switch for interactive approval prompts.
+    ///
+    /// When `false`, the approval gate itself does not request approval,
+    /// though agent-mode enforcement may still block a tool before execution.
     pub enabled: bool,
 
     /// Which approval policy to apply.
@@ -124,8 +126,8 @@ pub struct ApprovalConfig {
 impl Default for ApprovalConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
-            policy: ApprovalPolicyConfig::AlwaysAllow,
+            enabled: true,
+            policy: ApprovalPolicyConfig::RequireForDangerous,
             require_for: Vec::new(),
             dangerous_tools: ApprovalGate::default_dangerous_tools(),
             auto_approve_timeout_secs: 0,
@@ -511,8 +513,8 @@ mod tests {
     fn test_default_config() {
         let config = ApprovalConfig::default();
 
-        assert!(!config.enabled);
-        assert_eq!(config.policy, ApprovalPolicyConfig::AlwaysAllow);
+        assert!(config.enabled);
+        assert_eq!(config.policy, ApprovalPolicyConfig::RequireForDangerous);
         assert!(config.require_for.is_empty());
         assert_eq!(
             config.dangerous_tools,
@@ -738,7 +740,10 @@ mod tests {
         });
         assert!(enabled_gate.is_enabled());
 
-        let disabled_gate = ApprovalGate::new(ApprovalConfig::default());
+        let disabled_gate = ApprovalGate::new(ApprovalConfig {
+            enabled: false,
+            ..Default::default()
+        });
         assert!(!disabled_gate.is_enabled());
     }
 


### PR DESCRIPTION
## Summary

- **Interactive CLI approval prompts**: TTY-gated inline `[y/N]` prompts for dangerous tools via new `ApprovalHandler` callback on `AgentLoop`
- **Trusted local session**: `/trust on|off` slash command bypasses approval prompts for the current interactive CLI session (cannot activate from non-CLI channels or batch)
- **Streaming tool loop parity**: `process_message_streaming()` now mirrors non-streaming for hook callbacks (`before_tool`/`after_tool`/`on_error`), usage metric accounting, success/failure logging, thinking/response feedback phases, and malformed tool-argument parse preservation
- **Safer defaults**: agent mode `Autonomous` → `Assistant`, approval policy `AlwaysAllow(disabled)` → `RequireForDangerous(enabled)`, added `google` to default dangerous tools

## Test plan

- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test --lib` passes (3150 passed, 6 ignored after test fix)
- [ ] Interactive CLI: `zeptoclaw agent` shows `[Approval Required]` prompt for `shell` tool
- [ ] `/trust on` bypasses approval, `/trust off` re-enables it
- [ ] Non-TTY (piped) input does not show approval prompts
- [ ] Existing configs with `agent_mode: "autonomous"` still work unchanged
- [ ] Gateway/Telegram channels unaffected (no approval handler installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive CLI sessions now include tool approval prompts for dangerous operations.
  * Added trust management commands to bypass approvals in local sessions.
  * Enhanced terminal detection for improved interactive mode support.

* **Chores**
  * Changed default execution mode to safer assistant mode with approval requirements for dangerous tools.
  * Updated default dangerous tools list and approval policies.
  * Added new test fixtures for comparative agent behavior testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->