### PR TITLE
feat(telegram): markdown formatting and typing indicator

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -1116,6 +1116,18 @@ impl Channel for TelegramChannel {
     }
 }
 
+impl Drop for TelegramChannel {
+    fn drop(&mut self) {
+        // Best-effort abort of typing tasks without async.
+        // In async context, stop() should be called instead.
+        if let Ok(mut map) = self.typing_tasks.try_lock() {
+            for (_, handle) in map.drain() {
+                handle.abort();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Closes #331

- **Markdown-to-HTML formatting**: LLM output now renders properly in Telegram — `**bold**`, `*italic*`, `` `inline code` ``, and fenced code blocks all convert to HTML tags. Uses a 7-phase placeholder pipeline with LazyLock-cached regexes. Code blocks are extracted first so markdown inside code is never formatted.
- **Plain-text fallback**: If Telegram rejects the HTML markup, retries as plain text so the user always gets a response.
- **Typing indicator**: Bot shows "typing..." while the agent processes. Spawns a per-chat `send_chat_action(Typing)` loop every 4s on inbound messages, cancels unconditionally when the response is sent or the channel stops.

## Test plan

- [x] 18 new formatter tests (fenced code, inline code, bold, italic, edge cases)
- [x] 3 new typing indicator map tests (insert/remove, replace-aborts-old, cleanup-all)
- [x] Existing render tests pass (HTML escaping, spoiler pairs)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Full lib suite: 3181 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typing indicators now display in Telegram chats while processing messages.

* **Bug Fixes**
  * Enhanced text formatting rendering for bold, italic, spoilers, and code blocks.
  * Improved message sending with fallback to plain text when HTML formatting fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->