### PR TITLE
feat(providers): add Novita AI provider

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -584,6 +584,22 @@ impl Config {
                 .api_base = Some(val);
         }
 
+        // Novita AI
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NOVITA_API_KEY")
+            .or_else(|_| std::env::var("NOVITA_API_KEY"))
+        {
+            self.providers
+                .novita
+                .get_or_insert_with(ProviderConfig::default)
+                .api_key = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NOVITA_API_BASE") {
+            self.providers
+                .novita
+                .get_or_insert_with(ProviderConfig::default)
+                .api_base = Some(val);
+        }
+
         // Per-provider model overrides
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_ANTHROPIC_MODEL") {
             self.providers
@@ -660,6 +676,12 @@ impl Config {
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_QIANFAN_MODEL") {
             self.providers
                 .qianfan
+                .get_or_insert_with(ProviderConfig::default)
+                .model = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NOVITA_MODEL") {
+            self.providers
+                .novita
                 .get_or_insert_with(ProviderConfig::default)
                 .model = Some(val);
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1370,6 +1370,9 @@ pub struct ProvidersConfig {
     /// Baidu Qianfan configuration (OpenAI-compatible v2 endpoint).
     #[serde(default)]
     pub qianfan: Option<ProviderConfig>,
+    /// Novita AI configuration (OpenAI-compatible endpoint).
+    #[serde(default)]
+    pub novita: Option<ProviderConfig>,
     /// Retry behavior for runtime provider calls
     pub retry: RetryConfig,
     /// Fallback behavior across multiple configured runtime providers

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -52,6 +52,7 @@ pub const RUNTIME_SUPPORTED_PROVIDERS: &[&str] = &[
     "bedrock",
     "xai",
     "qianfan",
+    "novita",
 ];
 
 use crate::error::ProviderError;

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -203,6 +203,16 @@ pub const PROVIDER_REGISTRY: &[ProviderSpec] = &[
         default_api_version: None,
         api_key_required: true,
     },
+    ProviderSpec {
+        name: "novita",
+        model_keywords: &["novita"],
+        runtime_supported: true,
+        default_base_url: Some("https://api.novita.ai/openai"),
+        backend: "openai",
+        default_auth_header: None,
+        default_api_version: None,
+        api_key_required: true,
+    },
 ];
 
 pub fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a ProviderConfig> {
@@ -222,6 +232,7 @@ pub fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a
         "bedrock" => config.providers.bedrock.as_ref(),
         "xai" => config.providers.xai.as_ref(),
         "qianfan" => config.providers.qianfan.as_ref(),
+        "novita" => config.providers.novita.as_ref(),
         _ => None,
     }
 }
@@ -937,6 +948,23 @@ mod tests {
         assert_eq!(
             selected.api_base.as_deref(),
             Some("https://qianfan.baidubce.com/v2")
+        );
+    }
+
+    #[test]
+    fn test_novita_resolves_with_default_base_url() {
+        let mut config = Config::default();
+        config.providers.novita = Some(ProviderConfig {
+            api_key: Some("novita-test-key".to_string()),
+            ..Default::default()
+        });
+
+        let selected = resolve_runtime_provider(&config).expect("provider should resolve");
+        assert_eq!(selected.name, "novita");
+        assert_eq!(selected.backend, "openai");
+        assert_eq!(
+            selected.api_base.as_deref(),
+            Some("https://api.novita.ai/openai")
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds Novita AI as an OpenAI-compatible LLM provider (`https://api.novita.ai/openai`)
- Follows the same pattern as existing providers (xai, qianfan, deepseek, etc.)
- API key resolved from `ZEPTOCLAW_PROVIDERS_NOVITA_API_KEY` or `NOVITA_API_KEY`
- Supports `ZEPTOCLAW_PROVIDERS_NOVITA_API_BASE` and `ZEPTOCLAW_PROVIDERS_NOVITA_MODEL` env overrides

## Config example

```toml
[providers.novita]
api_key = "your-novita-api-key"
model = "moonshotai/kimi-k2.5"
```

## Test plan

- [ ] `cargo test --lib providers::registry` — all 37 tests pass including new `test_novita_resolves_with_default_base_url`
- [ ] `cargo build` — clean compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Novita AI provider with configurable API key, base URL, and model overrides through environment variables or configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->