### PR TITLE
fix(safety): prevent empty taint snippets from causing false positives

### DIFF
--- a/src/safety/taint.rs
+++ b/src/safety/taint.rs
@@ -874,7 +874,6 @@ mod tests {
     #[test]
     fn test_hardcoded_network_tools_still_tainted() {
         // web_fetch should be tainted even without being in external_tool_names
-        let engine = TaintEngine::new(TaintConfig::default());
         assert!(NETWORK_SOURCE_TOOLS.contains(&"web_fetch"));
 
         let mut engine = TaintEngine::new(TaintConfig::default());


### PR DESCRIPTION
## Summary

- Fixes a bug where an external tool returning empty output would store an empty snippet in the taint engine. Since `String::contains("")` is always `true` in Rust, this caused every subsequent `check_sink()` call to false-positive as tainted for the rest of the session.
- Adds a regression test that verifies empty output doesn't store a snippet and doesn't cause false positives on later sink checks.

Follow-up from #396.

## Test plan

- [x] `cargo nextest run --lib -E 'test(taint)'` — all 41 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty tool outputs in taint analysis to prevent false positives; empty outputs no longer create stored tainted snippets while taint labels from external tools remain recognized for validation.

* **Tests**
  * Added/updated tests to verify empty output handling and ensure sink checks behave correctly when tools return empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->