### PR TITLE
chore: accept PR #287 dev container tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ docs/
 *.md
 
 # Development files
+!scripts/artifacts/
 .env
 .env.*
 *.log
@@ -42,7 +43,6 @@ assets/
 deploy/
 examples/
 panel/
-scripts/
 install.sh
 Makefile
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ target/
 .cursor/
 .aider*
 .codex/
+.pi/
 
 # Worktrees
 .worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,6 +321,18 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
+[lints.clippy]
+# Suppress pre-#187 chore lints
+unnecessary_unwrap = "allow"
+uninlined_format_args = "allow"
+field_reassign_with_default = "allow"
+default_constructed_unit_structs = "allow"
+assertions_on_constants = "allow"
+unnecessary_get_then_check = "allow"
+
+[lints.rust]
+deprecated = "allow"
+
 [[bin]]
 name = "zeptoclaw"
 path = "src/main.rs"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,55 @@
+# Containerized Devtools (Podman Rootless)
+
+## Quick Setup
+
+**Podman** rootless (docker dropped).
+
+**Admin (one-time)**: `usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $USER; podman system migrate`
+
+**sccache (required)**:
+Host: `curl -sSf https://raw.githubusercontent.com/mozilla/sccache/master/install.sh | sh`
+Env: `export RUSTC_WRAPPER=sccache && source ~/.bashrc`
+
+## Usage
+
+```bash
+# Tests
+./scripts/test-container.sh lib                    # cargo nextest --lib
+./scripts/test-container.sh integration            # cargo test
+./scripts/test-container.sh all extra args...      # nextest lib + test + passthru
+
+# Lint (AGENTS.md gates)
+./scripts/lint-container.sh                        # clippy/fmt/doc
+
+# Bench
+./scripts/bench-container.sh                       # cargo bench message_bus --no-run
+
+# Podman
+CONTAINER_RUNTIME=podman ./scripts/test-container.sh lib
+
+# sccache
+./scripts/test-container.sh lib --sccache
+```
+
+## Cache Prune
+
+**Docker:** `docker builder prune --filter type=cache`
+
+**Podman:** `podman volume prune` (or `podman volume rm zeptoclaw-*`)
+
+## Pre-Push Workflow (Recommended)
+
+```bash
+./scripts/lint-container.sh
+./scripts/test-container.sh lib
+./scripts/bench-container.sh
+```
+
+Add to .git/hooks/pre-push for auto.
+
+## Troubleshooting
+
+- Slow first run: Image pull/deps.
+- Podman vols missing: Create above.
+- sccache miss: Host env set?
+- Integrity: `cargo clean` + prune if stale.

--- a/scripts/artifacts/clippy.toml
+++ b/scripts/artifacts/clippy.toml
@@ -1,0 +1,2 @@
+# clippy.toml
+allow-mixed-uninlined-format-args = true

--- a/scripts/bench-container.sh
+++ b/scripts/bench-container.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$0")/container-base.sh"
+
+container_run "cargo bench --bench message_bus --no-run"

--- a/scripts/container-base.sh
+++ b/scripts/container-base.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+# Base library for containerized devtools (design + Dockerfile.tests deps note)
+# Usage: source scripts/container-base.sh ; container_run "cargo nextest --lib"
+# Podman default/fallback docker. Podman vols: podman volume create zeptoclaw-{target,registry,benches}_cache
+
+# Pre-qualified fallback. Custom: docker build -t zeptodev Dockerfile.dev (podman: -t localhost/zeptodev)
+IMAGE="${IMAGE:-docker.io/library/rust:1.93-slim}"  
+WORKDIR="/src"
+
+# Podman preferred, fallback docker
+if ! command -v podman >/dev/null 2>&1; then
+  echo "Podman required for rootless containers (see rootless tutorial)." >&2
+  exit 1
+fi
+RUNTIME="podman"
+TARGET_MOUNT="-v zeptoclaw-target_cache:/src/target:rw,U"
+REGISTRY_MOUNT="-v zeptoclaw-registry_cache:/cargo-home:rw,U"
+BENCH_MOUNT="-v zeptoclaw-benches_cache:/src/benches/target:rw,U"
+
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
+
+SCCACHE_MOUNT="-v $HOME/.cache/sccache:/root/.cache/sccache:rw,U"  # Host sccache (user: curl install.sh; export RUSTC_WRAPPER=sccache)
+
+# Check if stdin is a TTY and set flags accordingly
+TTY_FLAG=""
+if [ -t 0 ] && [ -t 1 ]; then
+    TTY_FLAG="-it"
+else
+    TTY_FLAG="-i"
+fi
+
+printf "%s\n" target registry benches | xargs -I{} podman volume create --ignore zeptoclaw-{}_cache &>/dev/null
+
+container_run() {
+  # Override CARGO_HOME and mount for rootless Podman (avoids /usr/local/cargo root perms)
+  local cmd=("$@")
+  $CONTAINER_RUNTIME run --userns=keep-id --rm $TTY_FLAG \
+    -w "$WORKDIR" \
+    -v "$(pwd):/src:Z" \
+    -v "$(pwd)/scripts/artifacts/clippy.toml:/clippy.toml:Z" \
+    -e CARGO_HOME=/cargo-home \
+    $TARGET_MOUNT $REGISTRY_MOUNT $BENCH_MOUNT $SCCACHE_MOUNT \
+    $IMAGE \
+    bash -c "${cmd[*]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    container_run "$@"
+fi

--- a/scripts/fix-container.sh
+++ b/scripts/fix-container.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$(dirname "$0")/container-base.sh"
+
+# Check if stdin is a TTY and set flags accordingly
+TTY_FLAG=""
+if [ -t 0 ] && [ -t 1 ]; then
+    TTY_FLAG="-it"
+else
+    TTY_FLAG="-i"
+fi
+
+# Auto-build zeptodev if missing (docker: zeptodev, podman: localhost/zeptodev)
+IMAGE_TAG="zeptodev"
+if [[ "$RUNTIME" == "podman" ]]; then
+    IMAGE_TAG="localhost/${IMAGE_TAG}:custom"
+
+    if ! $RUNTIME image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+      echo "Building $IMAGE_TAG first-run image (Dockerfile.dev)..."
+
+      buildah bud \
+      --userns=host \
+      -f "$REPO_ROOT/Dockerfile.dev" \
+      -t "${IMAGE_TAG}" .
+    fi
+fi
+
+# Use pre-built
+ORIGINAL_IMAGE="$IMAGE"
+IMAGE="$IMAGE_TAG"
+trap 'IMAGE="$ORIGINAL_IMAGE"' EXIT
+
+container_run "cargo clippy --fix --allow-dirty --all-targets --config /clippy.toml"

--- a/scripts/test-container.sh
+++ b/scripts/test-container.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$0")/container-base.sh"
+
+MODE="${1:-all}"
+shift || true
+
+case "$MODE" in
+  lib)
+    container_run "cargo install cargo-nextest --locked || true && cargo nextest run --lib" "$@"
+    ;;
+  integration)
+    container_run "cargo test" "$@"
+    ;;
+  all)
+    container_run "cargo install --locked cargo-nextest || true && cargo nextest run --lib && cargo test" "$@"
+    ;;
+  *)
+    echo "Usage: $0 [lib|integration|all] [cargo args...]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Applies changes from @taqtiqa-mark's PR #287 (containerized dev tools for consistent pre-PR state)
- Adds `container-base.sh`, `test-container.sh`, `bench-container.sh`, `fix-container.sh` scripts
- Adds `scripts/artifacts/clippy.toml` and `docs/scripts.md`
- Includes `Cargo.toml` lint suppressions (to be reverted in follow-up PR)
- Updates `.dockerignore` and `.gitignore`

Closes #287

## Note
The `[lints.clippy]` and `[lints.rust]` suppressions in `Cargo.toml` will be addressed in a follow-up PR that fixes the underlying lint issues instead of suppressing them.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container-based development scripts for running tests, benchmarks, and automatic code fixes in isolated environments

* **Documentation**
  * Added comprehensive guide for container-based development setup, configuration, and recommended workflows

* **Chores**
  * Updated compiler linting configuration
  * Refined build context and version control ignore patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->