### PR TITLE
feat(telegram): add photo and image document support

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -786,25 +786,6 @@ impl Channel for TelegramChannel {
                                 .unwrap_or(false);
                             let has_image = has_photo || has_image_doc;
 
-                            // Debug: write media type detection to file for troubleshooting
-                            {
-                                let debug_msg = format!(
-                                    "[{}] photo={} doc={} animation={} video={} sticker={} text={} caption={:?}\n",
-                                    chrono::Utc::now().format("%H:%M:%S"),
-                                    msg.photo().is_some(),
-                                    msg.document().map(|d| format!("mime={:?}", d.mime_type)).unwrap_or_else(|| "none".into()),
-                                    msg.animation().is_some(),
-                                    msg.video().is_some(),
-                                    msg.sticker().is_some(),
-                                    msg.text().is_some(),
-                                    msg.caption().map(|c| crate::utils::string::preview(c, 50)),
-                                );
-                                let _ = std::fs::OpenOptions::new()
-                                    .create(true)
-                                    .append(true)
-                                    .open("/home/ironbank/.zeptoclaw/sessions/telegram_debug.log")
-                                    .and_then(|mut f| std::io::Write::write_all(&mut f, debug_msg.as_bytes()));
-                            }
                             if let Some(text) = msg.text()
                                 .or_else(|| msg.caption())
                                 .or(if has_image { Some(BARE_PHOTO_PLACEHOLDER) } else { None })


### PR DESCRIPTION
## Summary

Cherry-picked from #420 by @stuartbowness with debug logging removed and clippy fix applied.

Fixes Telegram photo messages being silently dropped. The message pipeline was gated on `msg.text()` which misses photo messages (captions are in `msg.caption()`). Also adds support for images sent as file attachments via `msg.document()`.

Changes:
- Caption fallback: `msg.text().or_else(|| msg.caption())`
- Bare photo support with synthetic placeholder prompt
- Image document detection for `image/*` MIME types
- Extracted `download_telegram_photo()` helper with timeouts
- MIME type fix for Telegram's `application/octet-stream` content-type
- User error feedback on download failure
- **Removed debug logging** that wrote to hardcoded path
- **Fixed clippy**: gated `provider_name_for_model_with_available` with `#[cfg(test)]`

## Related Issue

Closes #419

## Security Considerations

- Downloaded images capped at `MAX_IMAGE_SIZE` (20 MB)
- Download URLs from Telegram file API (trusted source)
- HTTP client uses 30s timeout
- Non-image MIME types filtered and defaulted to `image/jpeg`

## Test Plan

- [x] `cargo nextest run --lib -E 'test(telegram)'` — 62 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Credit: @stuartbowness (original implementation in #420)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram image and photo messages.
  * Image-only messages are now processed seamlessly.

* **Bug Fixes**
  * Added user notification when image downloads fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->