### PR TITLE
fix: prefer Podman in lint-container.sh (#424)

### DIFF
--- a/scripts/lint-container.sh
+++ b/scripts/lint-container.sh
@@ -27,6 +27,13 @@ done
 
 detect_engine() {
   if [ -n "${CONTAINER_ENGINE:-}" ]; then
+    case "$CONTAINER_ENGINE" in
+      docker|podman) ;;
+      *)
+        echo "Error: CONTAINER_ENGINE must be 'docker' or 'podman'" >&2
+        exit 1
+        ;;
+    esac
     if ! command -v "$CONTAINER_ENGINE" &>/dev/null; then
       echo "Error: CONTAINER_ENGINE=$CONTAINER_ENGINE not found" >&2
       exit 1


### PR DESCRIPTION
## Summary

- Flip engine detection to prefer Podman over Docker — avoids buildx `docker-container` driver failures on systems where both are installed
- Add `CONTAINER_ENGINE` env var override for explicit engine selection
- Update usage header in script

## Test plan

- [x] `CONTAINER_ENGINE=docker ./scripts/lint-container.sh` — uses docker
- [x] `CONTAINER_ENGINE=podman ./scripts/lint-container.sh` — uses podman
- [x] `CONTAINER_ENGINE=nonexistent ./scripts/lint-container.sh` — errors with clear message

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container engine detection and validation in the linting script.
  * Added explicit environment override for selecting the engine and clearer error reporting when no usable engine is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->