### PR TITLE
fix(agent): use full day-of-week name to prevent LLM hallucination

### DIFF
--- a/src/agent/context.rs
+++ b/src/agent/context.rs
@@ -10,10 +10,11 @@ use crate::session::Message;
 
 /// Format a timestamp envelope for a user message.
 ///
-/// Returns a string like "[Mon 2026-02-16 12:51 +08:00]" to prepend to user messages.
+/// Returns a string like "[Monday 2026-02-16 12:51 +08:00]" to prepend to user messages.
 /// Uses the system's local timezone via `chrono::Local`.
+/// Full day-of-week name (%A) is used to prevent LLM day-of-week hallucination.
 pub fn format_message_envelope() -> String {
-    format!("[{}]", Local::now().format("%a %Y-%m-%d %H:%M %:z"))
+    format!("[{}]", Local::now().format("%A %Y-%m-%d %H:%M %:z"))
 }
 
 /// Default system prompt for ZeptoClaw agent
@@ -225,8 +226,9 @@ impl RuntimeContext {
             let now = Local::now();
             parts.push(format!(
                 "- Current time: {}",
-                now.format("%a %Y-%m-%d %H:%M %:z")
+                now.format("%A, %Y-%m-%d %H:%M %:z")
             ));
+            parts.push(format!("- Today is: {}", now.format("%A, %B %-d, %Y")));
             parts.push(format!("- Timezone: {}", now.format("%:z")));
         }
         if let Some(ref workspace) = self.workspace {


### PR DESCRIPTION
## Summary
- Change `%a` (abbreviated) to `%A` (full) day-of-week name in message envelope and runtime context timestamp formatting
- Add explicit "Today is: Monday, March 25, 2026" line in runtime context for unambiguous date awareness
- Prevents LLM day-of-week hallucination when the model only sees an abbreviated name

Split out from #421 per review feedback — this is a behavior change, not docs.

Closes #

## Test plan
- [x] Existing `context` tests pass
- [ ] Verify message envelope shows full day name (e.g. "Monday" not "Mon")
- [ ] Verify runtime context includes "Today is" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated timestamp formatting to display full day names instead of abbreviated versions.
  * Enhanced date context display by adding a detailed "Today is:" line showing the full day name with month and year information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->