### PR TITLE
feat(telegram): reply-to threading for outbound messages

### DIFF
--- a/src/agent/loop.rs
+++ b/src/agent/loop.rs
@@ -237,6 +237,11 @@ fn propagate_routing_metadata(outbound: &mut OutboundMessage, inbound: &InboundM
             .metadata
             .insert("telegram_thread_id".to_string(), tid.clone());
     }
+    if let Some(mid) = inbound.metadata.get("telegram_message_id") {
+        outbound
+            .metadata
+            .insert("telegram_message_id".to_string(), mid.clone());
+    }
 }
 
 /// Convert an inbound message with optional media attachments into a session Message.

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -1007,7 +1007,8 @@ impl Channel for TelegramChannel {
                                     InboundMessage::new("telegram", &user_id, &chat_id, text);
 
                                 // Attach the inbound message ID so send() can
-                                // cancel the correct per-message typing indicator.
+                                // cancel the correct per-message typing indicator
+                                // and thread the reply back to this message.
                                 inbound = inbound.with_metadata(
                                     "telegram_message_id",
                                     &msg.id.0.to_string(),
@@ -1174,7 +1175,7 @@ impl Channel for TelegramChannel {
     /// - The Telegram API request fails
     async fn send(&self, msg: OutboundMessage) -> Result<()> {
         use teloxide::prelude::*;
-        use teloxide::types::{ChatId, ParseMode};
+        use teloxide::types::{ChatId, MessageId, ParseMode, ReplyParameters};
 
         if !self.running.load(Ordering::SeqCst) {
             warn!("Telegram channel not running, cannot send message");
@@ -1219,6 +1220,21 @@ impl Channel for TelegramChannel {
             if let Ok(tid) = thread_id_str.parse::<i32>() {
                 req = req
                     .message_thread_id(teloxide::types::ThreadId(teloxide::types::MessageId(tid)));
+            }
+        }
+
+        // Thread the reply back to the original inbound message.
+        {
+            let reply_id = msg
+                .reply_to
+                .as_deref()
+                .or(msg.metadata.get("telegram_message_id").map(|s| s.as_str()));
+            if let Some(id_str) = reply_id {
+                if let Ok(id) = id_str.parse::<i32>() {
+                    req = req.reply_parameters(
+                        ReplyParameters::new(MessageId(id)).allow_sending_without_reply(),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Outbound Telegram messages now reply-to the original inbound message, creating a visible thread in the chat
- Uses `reply_parameters` with `allow_sending_without_reply` for graceful fallback
- Supports explicit `reply_to` on `OutboundMessage` as well as automatic threading via `telegram_message_id` metadata

Replaces #429 (rebased to resolve conflicts from merged history).

## Test plan
- [x] Existing telegram tests pass
- [ ] Send a message in Telegram — bot response should appear as a reply to the user's message
- [ ] Forum topic messages should still route correctly with reply threading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram messages now support reply threading, allowing users to reply to specific messages within conversations and maintain proper message threading context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->