### PR TITLE
feat(telegram): add reaction indicator for message processing

### DIFF
--- a/src/agent/loop.rs
+++ b/src/agent/loop.rs
@@ -1445,11 +1445,16 @@ impl AgentLoop {
                                     ctx.chat_id.as_deref().unwrap_or(""),
                                     user_msg,
                                 );
-                                // Propagate routing metadata (e.g. telegram_thread_id)
+                                // Propagate routing metadata (e.g. telegram_thread_id, telegram_message_id)
                                 if let Some(tid) = inbound_meta.get("telegram_thread_id") {
                                     outbound
                                         .metadata
                                         .insert("telegram_thread_id".to_string(), tid.clone());
+                                }
+                                if let Some(mid) = inbound_meta.get("telegram_message_id") {
+                                    outbound
+                                        .metadata
+                                        .insert("telegram_message_id".to_string(), mid.clone());
                                 }
                                 let _ = bus_for_tools.publish_outbound(outbound).await;
                             }
@@ -2102,11 +2107,16 @@ impl AgentLoop {
                                     ctx.chat_id.as_deref().unwrap_or(""),
                                     user_msg,
                                 );
-                                // Propagate routing metadata (e.g. telegram_thread_id)
+                                // Propagate routing metadata (e.g. telegram_thread_id, telegram_message_id)
                                 if let Some(tid) = inbound_meta.get("telegram_thread_id") {
                                     outbound
                                         .metadata
                                         .insert("telegram_thread_id".to_string(), tid.clone());
+                                }
+                                if let Some(mid) = inbound_meta.get("telegram_message_id") {
+                                    outbound
+                                        .metadata
+                                        .insert("telegram_message_id".to_string(), mid.clone());
                                 }
                                 let _ = bus_for_tools.publish_outbound(outbound).await;
                             }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -78,6 +78,8 @@ use super::{BaseChannelConfig, Channel};
 struct Allowlist(Vec<String>);
 #[derive(Clone, Copy)]
 struct AllowUsernames(bool);
+#[derive(Clone, Copy)]
+struct ReactionsEnabled(bool);
 #[derive(Clone)]
 struct DefaultModel(String);
 #[derive(Clone)]
@@ -593,6 +595,7 @@ impl Channel for TelegramChannel {
             models: self.configured_models.clone(),
         };
         let longterm_memory = self.longterm_memory.clone();
+        let reactions_enabled = ReactionsEnabled(self.config.reactions);
         let http_client = self.http_client.clone();
         // Share the same running flag with the spawned task so state stays in sync
         let running_clone = Arc::clone(&self.running);
@@ -681,6 +684,7 @@ impl Channel for TelegramChannel {
                          Allowlist(allowlist): Allowlist,
                          AllowUsernames(allow_usernames): AllowUsernames,
                          deny_by_default: bool,
+                         ReactionsEnabled(reactions_enabled): ReactionsEnabled,
                          overrides_dep: OverridesDep,
                          DefaultModel(default_model): DefaultModel,
                          configured_providers_dep: ConfiguredProviders,
@@ -776,17 +780,6 @@ impl Channel for TelegramChannel {
                                     }
                                     typing_map.remove(&typing_map_key);
                                 });
-                            }
-
-                            // React with 👀 to acknowledge receipt before processing.
-                            {
-                                use teloxide::types::ReactionType;
-                                let _ = bot
-                                    .set_message_reaction(msg.chat.id, msg.id)
-                                    .reaction(vec![ReactionType::Emoji {
-                                        emoji: "\u{1F440}".to_string(),
-                                    }])
-                                    .await;
                             }
 
                             // Process text messages, captions, and bare photo/image messages
@@ -1013,6 +1006,20 @@ impl Channel for TelegramChannel {
                                     return Ok(());
                                 }
 
+                                // React with 👀 to acknowledge receipt before processing.
+                                if reactions_enabled {
+                                    use teloxide::types::ReactionType;
+                                    if let Err(e) = bot
+                                        .set_message_reaction(msg.chat.id, msg.id)
+                                        .reaction(vec![ReactionType::Emoji {
+                                            emoji: "\u{1F440}".to_string(),
+                                        }])
+                                        .await
+                                    {
+                                        debug!("Failed to set 👀 reaction: {}", e);
+                                    }
+                                }
+
                                 // Create and publish the inbound message
                                 let mut inbound =
                                     InboundMessage::new("telegram", &user_id, &chat_id, text);
@@ -1107,6 +1114,7 @@ impl Channel for TelegramChannel {
                         allowlist,
                         allow_usernames,
                         deny_by_default,
+                        reactions_enabled,
                         overrides_dep,
                         default_model,
                         configured_providers,
@@ -1213,23 +1221,13 @@ impl Channel for TelegramChannel {
             }
         }
 
+        info!("Telegram: Sending message to chat {}", chat_id);
+
         // Use cached bot instance
         let bot = self
             .bot
             .as_ref()
             .ok_or_else(|| ZeptoError::Channel("Telegram bot not initialized".to_string()))?;
-
-        // Clear the processing reaction (👀) set when the message was received.
-        if let Some(mid_str) = msg.metadata.get("telegram_message_id") {
-            if let Ok(mid) = mid_str.parse::<i32>() {
-                let _ = bot
-                    .set_message_reaction(ChatId(chat_id), MessageId(mid))
-                    .reaction(vec![ReactionType::Emoji {
-                        emoji: "\u{2705}".to_string(),
-                    }])
-                    .await;
-            }
-        }
 
         let rendered = render_telegram_html(&msg.content);
         let mut req = bot
@@ -1261,6 +1259,23 @@ impl Channel for TelegramChannel {
 
         req.await
             .map_err(|e| ZeptoError::Channel(format!("Failed to send Telegram message: {}", e)))?;
+
+        // Replace 👀 with ✅ now that the reply was sent successfully.
+        if self.config.reactions {
+            if let Some(mid_str) = msg.metadata.get("telegram_message_id") {
+                if let Ok(mid) = mid_str.parse::<i32>() {
+                    if let Err(e) = bot
+                        .set_message_reaction(ChatId(chat_id), MessageId(mid))
+                        .reaction(vec![ReactionType::Emoji {
+                            emoji: "\u{2705}".to_string(),
+                        }])
+                        .await
+                    {
+                        debug!("Failed to set ✅ reaction: {}", e);
+                    }
+                }
+            }
+        }
 
         info!("Telegram: Message sent successfully to chat {}", chat_id);
         Ok(())

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1102,6 +1102,10 @@ fn default_telegram_allow_usernames() -> bool {
     true
 }
 
+fn default_telegram_reactions() -> bool {
+    true
+}
+
 /// Telegram channel configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1124,6 +1128,9 @@ pub struct TelegramConfig {
     /// New configs should keep this disabled and use numeric Telegram user IDs only.
     #[serde(default = "default_telegram_allow_usernames")]
     pub allow_usernames: bool,
+    /// Whether to show processing reactions (👀 on receipt, ✅ on completion).
+    #[serde(default = "default_telegram_reactions")]
+    pub reactions: bool,
 }
 
 impl Default for TelegramConfig {
@@ -1134,6 +1141,7 @@ impl Default for TelegramConfig {
             allow_from: Vec::new(),
             deny_by_default: false,
             allow_usernames: default_telegram_allow_usernames(),
+            reactions: default_telegram_reactions(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add 👀 eyes reaction to inbound messages when processing begins
- Replace with ✅ checkmark reaction when the response is sent
- Provides visual feedback in Telegram that the bot has seen and is working on the message

Depends on #432. Replaces #430 (rebased to resolve conflicts from merged history).

## Test plan
- [x] Existing telegram tests pass
- [ ] Send a message — eyes reaction should appear immediately, then switch to checkmark when response arrives
- [ ] Verify reactions work in both direct chats and forum topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual processing indicators on Telegram: 👀 appears while the bot is handling a message and is replaced with ✅ when the reply is sent.
  * Replies are now threaded back to the originating Telegram message so conversations stay linked.

* **Chores**
  * Added a configurable option to enable/disable Telegram reaction indicators (enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->