### PR TITLE
fix: smarter container engine detection in lint-container.sh

### DIFF
--- a/scripts/lint-container.sh
+++ b/scripts/lint-container.sh
@@ -42,15 +42,22 @@ detect_engine() {
     return
   fi
 
-  # Prefer podman when available — it reads Dockerfiles natively and avoids
-  # buildx driver issues that break on some setups (see #424).
-  if command -v podman &>/dev/null; then
-    echo "podman"
+  # Try docker first (most common), but detect Podman-as-Docker (#435).
+  # Podman-as-Docker breaks buildx's docker-container driver (#424).
+  if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+    if docker info 2>/dev/null | grep -qi podman; then
+      # Docker CLI is actually a Podman alias — use podman directly
+      if command -v podman &>/dev/null; then
+        echo "podman"
+        return
+      fi
+    fi
+    echo "docker"
     return
   fi
 
-  if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
-    echo "docker"
+  if command -v podman &>/dev/null; then
+    echo "podman"
     return
   fi
 


### PR DESCRIPTION
## Summary
- Replaces "prefer Podman" logic from #426 with smarter auto-detection
- Docker stays the default for real Docker users
- Detects Podman-as-Docker via `docker info | grep podman` and switches to `podman` directly to avoid buildx driver issues
- `CONTAINER_ENGINE` env var override still bypasses everything

Closes #435

## Test plan
- [x] Real Docker + Podman installed → picks Docker
- [x] `CONTAINER_ENGINE=podman` override → picks Podman
- [ ] Podman-as-Docker system → picks `podman` directly (cc @taqtiqa-mark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container engine detection in the build process for enhanced compatibility across different containerization environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->