### PR TITLE
feat(web): quiet search output — status line instead of full results

### DIFF
--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -198,7 +198,7 @@ impl Tool for WebSearchTool {
             .collect::<Vec<_>>();
 
         if results.is_empty() {
-            return Ok(ToolOutput::user_visible(format!(
+            return Ok(ToolOutput::llm_only(format!(
                 "No web search results found for '{}'.",
                 query
             )));
@@ -216,7 +216,10 @@ impl Tool for WebSearchTool {
             output.push('\n');
         }
 
-        Ok(ToolOutput::user_visible(output.trim_end().to_string()))
+        Ok(ToolOutput::split(
+            output.trim_end().to_string(),
+            "Searching (Brave)...",
+        ))
     }
 }
 
@@ -375,7 +378,7 @@ impl Tool for DdgSearchTool {
         let results = parse_ddg_html(&html, count);
 
         if results.is_empty() {
-            return Ok(ToolOutput::user_visible(format!(
+            return Ok(ToolOutput::llm_only(format!(
                 "No web search results found for '{}'.",
                 query
             )));
@@ -393,7 +396,10 @@ impl Tool for DdgSearchTool {
             output.push('\n');
         }
 
-        Ok(ToolOutput::user_visible(output.trim_end().to_string()))
+        Ok(ToolOutput::split(
+            output.trim_end().to_string(),
+            "Searching (DuckDuckGo)...",
+        ))
     }
 }
 
@@ -549,7 +555,7 @@ impl Tool for SearxngSearchTool {
         let results = parse_searxng_json(&body, count)?;
 
         if results.is_empty() {
-            return Ok(ToolOutput::user_visible(format!(
+            return Ok(ToolOutput::llm_only(format!(
                 "No web search results found for '{}'.",
                 query
             )));
@@ -567,7 +573,10 @@ impl Tool for SearxngSearchTool {
             output.push('\n');
         }
 
-        Ok(ToolOutput::user_visible(output.trim_end().to_string()))
+        Ok(ToolOutput::split(
+            output.trim_end().to_string(),
+            "Searching (SearXNG)...",
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- Web search tools (Brave, DuckDuckGo, SearXNG) now use `ToolOutput::split` to send full results to the LLM while showing only a brief status line ("Searching (Brave)...") to the user
- Empty results use `llm_only` to avoid noisy "no results" messages in the UI

Split from #410 per review feedback.

## Test plan
- [x] All 154 web-related tests pass
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual: run a web search, verify user sees "Searching..." instead of full results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Web search tools now display results with provider identification information.
  * Adjusted visibility handling for search result messages and no-results scenarios across search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->