### PR TITLE
fix: NFC offset mapping, output truncation accuracy, r8r test assertions

### DIFF
--- a/src/tools/filesystem.rs
+++ b/src/tools/filesystem.rs
@@ -658,33 +658,70 @@ fn find_all_occurrences(haystack: &str, needle: &str) -> Vec<usize> {
 /// Map a byte range in an NFC-normalized string back to the original string.
 ///
 /// NFC normalization can merge multiple original chars into one (e.g. `e` +
-/// combining accent -> precomposed `é`). We build a byte-level mapping from
-/// NFC byte positions back to original byte positions by NFC-normalizing the
-/// original one char at a time and tracking boundaries.
+/// combining accent -> precomposed `é`). We normalize the full string (so
+/// cross-character composition happens correctly) and build a byte-level
+/// mapping by walking original characters alongside the NFC output.
 fn map_nfc_range_to_original(
     original: &str,
     _nfc: &str,
     nfc_start: usize,
     nfc_end: usize,
 ) -> (usize, usize) {
-    // Build mapping: for each NFC byte, record which original byte it came from.
-    // A single original char may produce multiple NFC bytes (or fewer via composition).
-    let mut nfc_to_orig: Vec<usize> = Vec::new();
-    let mut orig_ends: Vec<usize> = Vec::new();
+    use unicode_normalization::UnicodeNormalization;
 
-    for (orig_byte, ch) in original.char_indices() {
-        let orig_next = orig_byte + ch.len_utf8();
-        for nfc_ch in ch.nfc() {
-            for _ in 0..nfc_ch.len_utf8() {
-                nfc_to_orig.push(orig_byte);
-                orig_ends.push(orig_next);
+    // Collect original char boundaries: (start_byte, end_byte) for each char.
+    let orig_indices: Vec<(usize, usize)> = original
+        .char_indices()
+        .map(|(i, ch)| (i, i + ch.len_utf8()))
+        .collect();
+
+    // For each NFC byte, record which original byte range it maps to.
+    let mut nfc_to_orig_start: Vec<usize> = Vec::new();
+    let mut nfc_to_orig_end: Vec<usize> = Vec::new();
+
+    // Walk NFC chars produced from the full original string, consuming
+    // original chars until the NFC of the accumulated slice matches the
+    // expected NFC char. For non-composing chars this is 1 iteration;
+    // for composed sequences (e + combining accent -> é) this is 2+.
+    let mut orig_idx = 0;
+    for nfc_ch in original.nfc() {
+        let orig_start_byte = orig_indices
+            .get(orig_idx)
+            .map(|&(s, _)| s)
+            .unwrap_or(original.len());
+
+        loop {
+            orig_idx += 1;
+            let scan_end = orig_indices
+                .get(orig_idx)
+                .map(|&(s, _)| s)
+                .unwrap_or(original.len());
+            let slice = &original[orig_start_byte..scan_end];
+            let normalized: String = slice.nfc().collect();
+            // Check if the NFC of this span is exactly our target char.
+            // "e".nfc() == "e" (not "é"), so this correctly keeps consuming
+            // until the combining mark is included: "e\u{0301}".nfc() == "é".
+            if (normalized.len() == nfc_ch.len_utf8() && normalized.starts_with(nfc_ch))
+                || orig_idx >= orig_indices.len()
+            {
+                break;
             }
+        }
+
+        let orig_end_byte = orig_indices
+            .get(orig_idx)
+            .map(|&(s, _)| s)
+            .unwrap_or(original.len());
+
+        for _ in 0..nfc_ch.len_utf8() {
+            nfc_to_orig_start.push(orig_start_byte);
+            nfc_to_orig_end.push(orig_end_byte);
         }
     }
 
-    let orig_start = nfc_to_orig.get(nfc_start).copied().unwrap_or(0);
+    let orig_start = nfc_to_orig_start.get(nfc_start).copied().unwrap_or(0);
     let orig_end = if nfc_end > 0 {
-        orig_ends
+        nfc_to_orig_end
             .get(nfc_end - 1)
             .copied()
             .unwrap_or(original.len())
@@ -1717,5 +1754,49 @@ mod tests {
     fn test_empty_content() {
         let result = find_unique_match("", "search");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_nfc_offset_map_combining_accent() {
+        use unicode_normalization::UnicodeNormalization;
+        // "e\u{0301}" is 3 bytes (e=1 + combining acute=2). NFC gives "é" (2 bytes).
+        // Searching for "é" should map back to the full 3-byte original span.
+        let original = "e\u{0301}";
+        let nfc: String = original.nfc().collect();
+        assert_eq!(nfc, "\u{00E9}");
+        let (start, end) = map_nfc_range_to_original(original, &nfc, 0, nfc.len());
+        assert_eq!(start, 0);
+        assert_eq!(end, original.len()); // 3 bytes
+    }
+
+    #[test]
+    fn test_nfc_offset_map_no_drift_after_composition() {
+        use unicode_normalization::UnicodeNormalization;
+        // "cafe\u{0301} x nai\u{0308}ve" — two composed sequences.
+        // Searching for "naïve" in the NFC form should map to the correct
+        // original bytes without drift from the earlier "é" composition.
+        let original = "cafe\u{0301} x nai\u{0308}ve";
+        let nfc: String = original.nfc().collect();
+        assert_eq!(nfc, "café x naïve");
+        // "naïve" starts at NFC byte 7 ("café x " = 7 bytes in NFC)
+        let naive_nfc_start = nfc.find("naïve").unwrap();
+        let naive_nfc_end = naive_nfc_start + "naïve".len();
+        let (start, end) =
+            map_nfc_range_to_original(original, &nfc, naive_nfc_start, naive_nfc_end);
+        // In original: "nai\u{0308}ve" starts at byte 9 ("cafe\u{0301} x " = 9 bytes)
+        let expected_start = original.find("nai").unwrap();
+        let expected_end = original.len();
+        assert_eq!(start, expected_start);
+        assert_eq!(end, expected_end);
+    }
+
+    #[test]
+    fn test_nfc_offset_map_ascii_identity() {
+        use unicode_normalization::UnicodeNormalization;
+        let original = "hello world";
+        let nfc: String = original.nfc().collect();
+        let (start, end) = map_nfc_range_to_original(original, &nfc, 6, 11);
+        assert_eq!(start, 6);
+        assert_eq!(end, 11);
     }
 }

--- a/src/tools/output.rs
+++ b/src/tools/output.rs
@@ -63,18 +63,20 @@ pub fn truncate_tool_output(output: &str, max_lines: usize, max_bytes: usize) ->
         if byte_count + segment_bytes > max_bytes {
             // How many bytes we can still take from this segment
             let remaining_budget = max_bytes.saturating_sub(byte_count);
+            let mut kept_from_segment = 0;
             if remaining_budget > 0 {
                 // Walk backward to a char boundary within the budget
                 let mut end = remaining_budget;
                 while end > 0 && !segment.is_char_boundary(end) {
                     end -= 1;
                 }
+                kept_from_segment = end;
                 if end > 0 {
                     result.push_str(&segment[..end]);
                 }
             }
             let total_bytes = output.len();
-            let kept_bytes = byte_count + remaining_budget;
+            let kept_bytes = byte_count + kept_from_segment;
             if !result.ends_with('\n') {
                 result.push('\n');
             }
@@ -164,5 +166,21 @@ mod tests {
         // Byte limit 100 (permissive), line limit 2
         let result2 = truncate_tool_output(&input, 2, 100);
         assert!(result2.contains("[output truncated at 2 lines"));
+    }
+
+    #[test]
+    fn byte_trailer_accurate_after_backtrack() {
+        // 4 emojis, each 4 bytes = 16 bytes total. Byte limit 6 falls mid-emoji.
+        // Backtrack keeps 1 emoji (4 bytes), so 12 bytes should be omitted.
+        let input = "\u{1F600}\u{1F600}\u{1F600}\u{1F600}";
+        assert_eq!(input.len(), 16);
+
+        let result = truncate_tool_output(input, DEFAULT_MAX_LINES, 6);
+        // After backtrack: kept 4 bytes (1 emoji), omitted 12
+        assert!(
+            result.contains("12 bytes omitted"),
+            "Expected '12 bytes omitted' in: {}",
+            result
+        );
     }
 }

--- a/src/tools/r8r.rs
+++ b/src/tools/r8r.rs
@@ -758,8 +758,8 @@ mod tests {
         let result = tool
             .execute(json!({"action": "list", "workflow": "_"}), &ctx)
             .await;
-        // Should either succeed or fail gracefully
-        assert!(result.is_ok() || result.is_err());
+        // Integration test: succeeds or fails gracefully (no panic).
+        let _result = result;
     }
 
     #[tokio::test]
@@ -780,9 +780,16 @@ mod tests {
             .await;
 
         // If r8r is running and workflow exists, should succeed
-        if let Ok(output_result) = result {
-            let output = output_result.for_llm;
-            assert!(output.contains("completed") || output.contains("Execution ID"));
+        match result {
+            Ok(output_result) => {
+                let output = output_result.for_llm;
+                assert!(
+                    output.contains("completed") || output.contains("Execution ID"),
+                    "Unexpected output: {}",
+                    output
+                );
+            }
+            Err(e) => eprintln!("r8r integration test skipped (server not reachable): {}", e),
         }
     }
 }


### PR DESCRIPTION
## Summary
- **NFC offset mapping**: Rewrite `map_nfc_range_to_original` to normalize the full string rather than per-character, fixing byte offset drift when multiple combining sequences appear in the same text (e.g. searching for "naïve" in "café x naïve" with decomposed Unicode)
- **Output truncation**: Fix byte trailer in `truncate_tool_output` to report accurate omitted byte count after char-boundary backtrack
- **r8r tests**: Improve integration test assertions with better error reporting

Split from #410 per review feedback.

## Test plan
- [x] 3 new NFC tests pass (combining accent, multi-composition drift, ASCII identity)
- [x] 1 new output truncation test passes (byte_trailer_accurate_after_backtrack)
- [x] All 95 filesystem/output/r8r tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of accented and composed Unicode characters in text processing.
  * Corrected byte-limit truncation behavior for multibyte UTF-8 character sequences.

* **Tests**
  * Added test coverage for character normalization edge cases.
  * Enhanced test robustness when optional service dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->