### PR TITLE
docs: minor formatting cleanups in plans and specs

### DIFF
--- a/docs/superpowers/plans/2026-03-21-tool-conformance-edit-truncation.md
+++ b/docs/superpowers/plans/2026-03-21-tool-conformance-edit-truncation.md
@@ -607,9 +607,7 @@ fn find_unique_match(content: &str, old_text: &str) -> std::result::Result<Uniqu
                 });
             }
             n if n > 1 => {
-                return Err(EditMatchError(format!(
-                    "Found {} occurrences", n
-                )));
+                return Err(EditMatchError::MultipleMatches(n));
             }
             _ => {}
         }
@@ -1303,7 +1301,7 @@ git add -A && git commit -m "chore: fmt + clippy fixups for #391"
 
 ## Task Dependency Graph
 
-```
+```text
 Task 1 (shared truncation) ─────→ Task 2 (apply to tools) ──┐
                                                               ├──→ Task 7 (fixture files) ──→ Task 8 (finalize)
 Task 3 (unicode-normalization) ──→ Task 4 (find_unique_match) ──→ Task 5 (wire into EditFileTool) ──┘

--- a/docs/superpowers/plans/2026-03-23-model-discoverability.md
+++ b/docs/superpowers/plans/2026-03-23-model-discoverability.md
@@ -971,12 +971,7 @@ Expected: ALL PASS
 git add src/ && git diff --cached --quiet || git commit -m "chore: fmt"
 ```
 
-- [ ] **Step 6: Update repo documentation**
-
-Update `CLAUDE.md`: architecture tree, test counts, module descriptions, any new CLI flags.
-Update `AGENTS.md`: project snapshot with current state.
-
-- [ ] **Step 7: Verify format check**
+- [ ] **Step 6: Verify format check**
 
 Run: `cargo fmt -- --check`
 Expected: No changes needed

--- a/docs/superpowers/specs/2026-03-21-tool-conformance-edit-truncation-design.md
+++ b/docs/superpowers/specs/2026-03-21-tool-conformance-edit-truncation-design.md
@@ -131,7 +131,7 @@ Add `pub mod output;` to `src/tools/mod.rs`.
 
 ### Structure
 
-```
+```text
 tests/
 ├── conformance.rs                  # Top-level test entry point
 └── conformance/


### PR DESCRIPTION
## Summary
- Fix `EditMatchError` variant name in tool conformance plan
- Add `text` fence annotations for ASCII diagrams
- Remove redundant "update repo documentation" step from model discoverability plan (handled in post-implementation checklist)

Split from #410 per review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal planning and specification documents to reflect current process and improve formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->