### PR TITLE
feat(providers): add Google Vertex AI provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f83bc5c208df4a6b38ad2a8d2b01c0d377811f9efe9b0733171f28dd74db9c3"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac",
+ "http",
+ "reqwest 0.13.2",
+ "rustc_version",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188909653b7c484e43695325c0324804b5645d568f8d2e4c8a6f520231d50956"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http",
+ "pin-project",
+ "rand 0.10.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd10e97751ca894f9dad6be69fcef1cb72f5bc187329e0254817778fc8235030"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ade65b0e4fa9cb4b6f147c8e726803bff453e3190910a53cbd3b0c019f5c2a"
+dependencies = [
+ "base64",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,6 +7164,7 @@ dependencies = [
  "gog-calendar",
  "gog-core",
  "gog-gmail",
+ "google-cloud-auth",
  "hex",
  "instant-distance",
  "json5 1.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,7 @@ jsonwebtoken = { version = "10", optional = true }
 # Password hashing for panel password auth mode
 bcrypt = { version = "0.19", optional = true }
 unicode-normalization = "0.1.25"
+google-cloud-auth = { version = "1.7.0", default-features = false }
 
 # USB device enumeration — only on platforms nusb supports (Linux, macOS, Windows)
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -372,7 +372,7 @@ pub(crate) async fn create_agent_with_template(
     // so /model can switch between them at runtime.
     for selection in resolve_runtime_providers(&config) {
         if let Some(provider) =
-            provider_from_runtime_selection(&selection, &config.agents.defaults.model)
+            provider_from_runtime_selection(&selection, &config.agents.defaults.model).await
         {
             agent
                 .set_provider_in_registry(selection.name, provider)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -420,6 +420,22 @@ impl Config {
             provider.api_base = Some(val);
         }
 
+        // Vertex AI (api_key = project ID, api_base = location)
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VERTEX_API_KEY") {
+            let provider = self
+                .providers
+                .vertex
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_key = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VERTEX_API_BASE") {
+            let provider = self
+                .providers
+                .vertex
+                .get_or_insert_with(ProviderConfig::default);
+            provider.api_base = Some(val);
+        }
+
         // vLLM
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VLLM_API_KEY") {
             let provider = self
@@ -616,6 +632,12 @@ impl Config {
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_GEMINI_MODEL") {
             self.providers
                 .gemini
+                .get_or_insert_with(ProviderConfig::default)
+                .model = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_VERTEX_MODEL") {
+            self.providers
+                .vertex
                 .get_or_insert_with(ProviderConfig::default)
                 .model = Some(val);
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1438,6 +1438,10 @@ pub struct ProvidersConfig {
     pub vllm: Option<ProviderConfig>,
     /// Google Gemini configuration
     pub gemini: Option<ProviderConfig>,
+    /// Google Vertex AI configuration (Gemini models via Vertex AI regional endpoints).
+    /// `api_key` holds the GCP project ID, `api_base` holds the location (e.g. "us-central1").
+    #[serde(default)]
+    pub vertex: Option<ProviderConfig>,
     /// Ollama (local models) configuration
     pub ollama: Option<ProviderConfig>,
     /// Nvidia NIM configuration

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -111,7 +111,9 @@ impl ZeptoKernel {
         // 5. Memory searcher + shared LTM
         let embedding_provider: Option<Arc<dyn LLMProvider>> =
             if matches!(config.memory.backend, MemoryBackend::Embedding) {
-                provider::build_runtime_provider_chain(&config).map(|(chain, _)| Arc::from(chain))
+                provider::build_runtime_provider_chain(&config)
+                    .await
+                    .map(|(chain, _)| Arc::from(chain))
             } else {
                 None
             };

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -25,7 +25,7 @@ pub async fn build_provider_chain(
     config: &Config,
 ) -> Option<(Arc<dyn LLMProvider>, Vec<&'static str>)> {
     refresh_oauth_credentials_if_needed(config).await;
-    let (chain, names) = build_runtime_provider_chain(config)?;
+    let (chain, names) = build_runtime_provider_chain(config).await?;
     let chain = apply_retry_wrapper(chain, config);
     Some((Arc::from(chain), names))
 }
@@ -37,7 +37,7 @@ pub async fn build_provider_chain(
 /// presets.
 ///
 /// Moved from `cli/common.rs:139–199`.
-pub fn provider_from_runtime_selection(
+pub async fn provider_from_runtime_selection(
     selection: &RuntimeProviderSelection,
     configured_model: &str,
 ) -> Option<Box<dyn LLMProvider>> {
@@ -95,6 +95,23 @@ pub fn provider_from_runtime_selection(
             );
             Some(Box::new(provider))
         }
+        "vertex" => {
+            // For Vertex: api_key holds the GCP project ID, api_base holds the location.
+            // Auth: VERTEX_ACCESS_TOKEN (static) → ADC (auto-refresh via google-cloud-auth).
+            let api_key = if selection.api_key.is_empty() {
+                None
+            } else {
+                Some(selection.api_key.as_str())
+            };
+            let api_base = selection.api_base.as_deref().filter(|b| !b.is_empty());
+            crate::providers::vertex::VertexProvider::from_config(
+                api_key,
+                api_base,
+                configured_model,
+            )
+            .await
+            .map(|p| Box::new(p) as Box<dyn LLMProvider>)
+        }
         _ => None,
     }
 }
@@ -112,7 +129,7 @@ struct RuntimeProviderCandidate {
 /// chains them with `FallbackProvider` when `providers.fallback.enabled`.
 ///
 /// Moved from `cli/common.rs:251–315`.
-pub fn build_runtime_provider_chain(
+pub async fn build_runtime_provider_chain(
     config: &Config,
 ) -> Option<(Box<dyn LLMProvider>, Vec<&'static str>)> {
     let mut candidates: Vec<RuntimeProviderCandidate> = Vec::new();
@@ -122,7 +139,8 @@ pub fn build_runtime_provider_chain(
     let quota_store = Arc::new(crate::providers::QuotaStore::load_or_default());
 
     for selection in resolve_runtime_providers(config) {
-        if let Some(provider) = provider_from_runtime_selection(&selection, configured_model) {
+        if let Some(provider) = provider_from_runtime_selection(&selection, configured_model).await
+        {
             let quota =
                 provider_config_by_name(config, selection.name).and_then(|pc| pc.quota.clone());
             let provider =
@@ -408,28 +426,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_build_runtime_provider_chain_empty_when_no_provider() {
+    #[tokio::test]
+    async fn test_build_runtime_provider_chain_empty_when_no_provider() {
         let config = Config::default();
-        assert!(build_runtime_provider_chain(&config).is_none());
+        assert!(build_runtime_provider_chain(&config).await.is_none());
     }
 
-    #[test]
-    fn test_build_runtime_provider_chain_single_provider() {
+    #[tokio::test]
+    async fn test_build_runtime_provider_chain_single_provider() {
         let mut config = Config::default();
         config.providers.openai = Some(crate::config::ProviderConfig {
             api_key: Some("sk-openai".to_string()),
             ..Default::default()
         });
 
-        let (provider, names) =
-            build_runtime_provider_chain(&config).expect("provider chain should resolve");
+        let (provider, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("provider chain should resolve");
         assert_eq!(names, vec!["openai"]);
         assert_eq!(provider.name(), "openai");
     }
 
-    #[test]
-    fn test_build_runtime_provider_chain_preserves_registry_order() {
+    #[tokio::test]
+    async fn test_build_runtime_provider_chain_preserves_registry_order() {
         let mut config = Config::default();
         config.providers.fallback.enabled = true;
         config.providers.anthropic = Some(crate::config::ProviderConfig {
@@ -445,8 +464,9 @@ mod tests {
             ..Default::default()
         });
 
-        let (provider, names) =
-            build_runtime_provider_chain(&config).expect("provider chain should resolve");
+        let (provider, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("provider chain should resolve");
         assert_eq!(names, vec!["anthropic", "openai", "groq"]);
 
         let chain_name = provider.name();
@@ -454,8 +474,8 @@ mod tests {
         assert!(chain_name.contains("openai"));
     }
 
-    #[test]
-    fn test_build_runtime_provider_chain_honors_preferred_fallback_provider() {
+    #[tokio::test]
+    async fn test_build_runtime_provider_chain_honors_preferred_fallback_provider() {
         let mut config = Config::default();
         config.providers.fallback.enabled = true;
         config.providers.fallback.provider = Some("groq".to_string());
@@ -472,13 +492,14 @@ mod tests {
             ..Default::default()
         });
 
-        let (_provider, names) =
-            build_runtime_provider_chain(&config).expect("provider chain should resolve");
+        let (_provider, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("provider chain should resolve");
         assert_eq!(names, vec!["anthropic", "groq", "openai"]);
     }
 
-    #[test]
-    fn test_build_runtime_provider_chain_no_chain_when_fallback_disabled() {
+    #[tokio::test]
+    async fn test_build_runtime_provider_chain_no_chain_when_fallback_disabled() {
         let mut config = Config::default();
         config.providers.fallback.enabled = false;
         config.providers.anthropic = Some(crate::config::ProviderConfig {
@@ -490,8 +511,9 @@ mod tests {
             ..Default::default()
         });
 
-        let (provider, names) =
-            build_runtime_provider_chain(&config).expect("provider chain should resolve");
+        let (provider, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("provider chain should resolve");
         // Only the highest-priority provider is used
         assert_eq!(names, vec!["anthropic"]);
         assert_eq!(provider.name(), "claude");
@@ -556,8 +578,8 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
-    #[test]
-    fn test_model_name_promotes_openai_over_anthropic() {
+    #[tokio::test]
+    async fn test_model_name_promotes_openai_over_anthropic() {
         let mut config = Config::default();
         config.agents.defaults.model = "gpt-4o".to_string();
         config.providers.anthropic = Some(crate::config::ProviderConfig {
@@ -568,16 +590,17 @@ mod tests {
             api_key: Some("sk-openai-test".to_string()),
             ..Default::default()
         });
-        let (_, names) =
-            build_runtime_provider_chain(&config).expect("should resolve with both keys present");
+        let (_, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("should resolve with both keys present");
         assert_eq!(
             names[0], "openai",
             "gpt-4o model should promote openai to first"
         );
     }
 
-    #[test]
-    fn test_model_name_keeps_anthropic_when_claude() {
+    #[tokio::test]
+    async fn test_model_name_keeps_anthropic_when_claude() {
         let mut config = Config::default();
         config.agents.defaults.model = "claude-sonnet-4-5-20250929".to_string();
         config.providers.anthropic = Some(crate::config::ProviderConfig {
@@ -588,16 +611,17 @@ mod tests {
             api_key: Some("sk-openai-test".to_string()),
             ..Default::default()
         });
-        let (_, names) =
-            build_runtime_provider_chain(&config).expect("should resolve with both keys present");
+        let (_, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("should resolve with both keys present");
         assert_eq!(
             names[0], "anthropic",
             "claude model should keep anthropic first"
         );
     }
 
-    #[test]
-    fn test_model_name_no_match_keeps_registry_order() {
+    #[tokio::test]
+    async fn test_model_name_no_match_keeps_registry_order() {
         let mut config = Config::default();
         config.agents.defaults.model = "some-unknown-model".to_string();
         config.providers.anthropic = Some(crate::config::ProviderConfig {
@@ -608,8 +632,9 @@ mod tests {
             api_key: Some("sk-openai-test".to_string()),
             ..Default::default()
         });
-        let (_, names) =
-            build_runtime_provider_chain(&config).expect("should resolve with both keys present");
+        let (_, names) = build_runtime_provider_chain(&config)
+            .await
+            .expect("should resolve with both keys present");
         assert_eq!(
             names[0], "anthropic",
             "unknown model should keep registry order"

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -336,7 +336,7 @@ impl GeminiProvider {
     }
 
     /// Parse token usage from a Gemini response if available.
-    fn extract_usage(response: &Value) -> Option<Usage> {
+    pub fn extract_usage(response: &Value) -> Option<Usage> {
         let meta = response.get("usageMetadata")?;
         let prompt = meta["promptTokenCount"].as_u64()? as u32;
         let completion = meta["candidatesTokenCount"].as_u64()? as u32;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub mod retry;
 pub mod rotation;
 pub mod structured;
 mod types;
+pub mod vertex;
 
 /// Provider IDs currently supported by the runtime.
 pub const RUNTIME_SUPPORTED_PROVIDERS: &[&str] = &[
@@ -44,6 +45,7 @@ pub const RUNTIME_SUPPORTED_PROVIDERS: &[&str] = &[
     "zhipu",
     "vllm",
     "gemini",
+    "vertex",
     "ollama",
     "nvidia",
     "deepseek",
@@ -79,6 +81,7 @@ pub use structured::{validate_json_response, OutputFormat};
 pub use types::{
     ChatOptions, LLMProvider, LLMResponse, LLMToolCall, StreamEvent, ToolDefinition, Usage,
 };
+pub use vertex::VertexProvider;
 
 /// Parse an HTTP status code and response body into a structured [`ProviderError`].
 ///

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -124,6 +124,16 @@ pub const PROVIDER_REGISTRY: &[ProviderSpec] = &[
         api_key_required: true,
     },
     ProviderSpec {
+        name: "vertex",
+        model_keywords: &["vertex"],
+        runtime_supported: true,
+        default_base_url: None, // constructed from project + location
+        backend: "vertex",
+        default_auth_header: None,
+        default_api_version: None,
+        api_key_required: false, // uses ADC or VERTEX_ACCESS_TOKEN; api_key holds project ID
+    },
+    ProviderSpec {
         name: "ollama",
         model_keywords: &["ollama"],
         runtime_supported: true,
@@ -224,6 +234,7 @@ pub fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a
         "zhipu" => config.providers.zhipu.as_ref(),
         "vllm" => config.providers.vllm.as_ref(),
         "gemini" => config.providers.gemini.as_ref(),
+        "vertex" => config.providers.vertex.as_ref(),
         "ollama" => config.providers.ollama.as_ref(),
         "nvidia" => config.providers.nvidia.as_ref(),
         "deepseek" => config.providers.deepseek.as_ref(),

--- a/src/providers/vertex.rs
+++ b/src/providers/vertex.rs
@@ -1,0 +1,487 @@
+//! Google Vertex AI provider.
+//!
+//! Uses the same `generateContent` request/response format as the Gemini
+//! provider, but routes through the Vertex AI regional endpoint with
+//! Application Default Credentials (ADC) for automatic token lifecycle.
+//!
+//! Auth priority:
+//! 1. `VERTEX_ACCESS_TOKEN` env var (manual bearer token, no refresh)
+//! 2. `GOOGLE_APPLICATION_CREDENTIALS` service account JSON (auto-refresh)
+//! 3. `gcloud auth application-default login` ADC (auto-refresh)
+//!
+//! Endpoint:
+//! `https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent`
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::debug;
+
+use crate::error::{Result, ZeptoError};
+use crate::session::{ContentPart, ImageSource, Message, Role};
+
+use super::gemini::GeminiProvider;
+use super::{parse_provider_error, ChatOptions, LLMProvider, LLMResponse, ToolDefinition};
+
+/// Default model when none is configured or passed at call time.
+const DEFAULT_VERTEX_MODEL: &str = "gemini-2.5-flash";
+
+/// OAuth scope required for Vertex AI API access.
+const VERTEX_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+/// Authentication method for Vertex AI.
+enum VertexAuth {
+    /// Static bearer token (from `VERTEX_ACCESS_TOKEN`). No auto-refresh.
+    Static(String),
+    /// ADC credential with automatic token refresh via `google-cloud-auth`.
+    Adc(Arc<google_cloud_auth::credentials::AccessTokenCredentials>),
+}
+
+impl std::fmt::Debug for VertexAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(_) => f.write_str("VertexAuth::Static([REDACTED])"),
+            Self::Adc(_) => f.write_str("VertexAuth::Adc"),
+        }
+    }
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+/// Google Vertex AI provider that speaks the Gemini `generateContent` API
+/// through the Vertex AI regional endpoint.
+///
+/// Supports both static bearer tokens and ADC with automatic refresh.
+pub struct VertexProvider {
+    project_id: String,
+    location: String,
+    auth: VertexAuth,
+    model: String,
+    client: Client,
+}
+
+impl std::fmt::Debug for VertexProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VertexProvider")
+            .field("project_id", &self.project_id)
+            .field("location", &self.location)
+            .field("auth", &self.auth)
+            .field("model", &self.model)
+            .finish()
+    }
+}
+
+impl VertexProvider {
+    /// Build a provider with a static bearer token.
+    pub fn new(project_id: &str, location: &str, bearer_token: &str, model: &str) -> Self {
+        Self {
+            project_id: project_id.to_string(),
+            location: location.to_string(),
+            auth: VertexAuth::Static(bearer_token.to_string()),
+            model: model.to_string(),
+            client: Self::build_client(),
+        }
+    }
+
+    /// Build a provider with ADC (Application Default Credentials).
+    ///
+    /// The token is automatically refreshed before expiry by `google-cloud-auth`.
+    pub fn with_adc(project_id: &str, location: &str, model: &str) -> Result<Self> {
+        let cred = google_cloud_auth::credentials::Builder::default()
+            .with_scopes([VERTEX_SCOPE])
+            .build_access_token_credentials()
+            .map_err(|e| ZeptoError::Provider(format!("Vertex AI ADC init failed: {e}")))?;
+
+        Ok(Self {
+            project_id: project_id.to_string(),
+            location: location.to_string(),
+            auth: VertexAuth::Adc(Arc::new(cred)),
+            model: model.to_string(),
+            client: Self::build_client(),
+        })
+    }
+
+    /// Build from config and environment variables.
+    ///
+    /// Resolution priority:
+    /// - **Project ID**: `api_key` config → `GOOGLE_CLOUD_PROJECT` → `VERTEX_PROJECT_ID`
+    /// - **Location**: `api_base` config → `GOOGLE_CLOUD_LOCATION` → `VERTEX_LOCATION` → `us-central1`
+    /// - **Auth**: `VERTEX_ACCESS_TOKEN` (static) → ADC (auto-refresh)
+    /// - **Model**: config model → `gemini-2.5-flash`
+    pub async fn from_config(
+        api_key: Option<&str>,
+        api_base: Option<&str>,
+        model: &str,
+    ) -> Option<Self> {
+        // Resolve project ID
+        let project_id = api_key
+            .filter(|k| !k.is_empty())
+            .map(String::from)
+            .or_else(|| std::env::var("GOOGLE_CLOUD_PROJECT").ok())
+            .or_else(|| std::env::var("VERTEX_PROJECT_ID").ok())?;
+
+        // Resolve location
+        let location = api_base
+            .filter(|b| !b.is_empty())
+            .map(String::from)
+            .or_else(|| std::env::var("GOOGLE_CLOUD_LOCATION").ok())
+            .or_else(|| std::env::var("VERTEX_LOCATION").ok())
+            .unwrap_or_else(|| "us-central1".to_string());
+
+        let model = if model.is_empty() {
+            DEFAULT_VERTEX_MODEL
+        } else {
+            model
+        };
+
+        // Try static token first (backward compat), then ADC
+        if let Some(token) = std::env::var("VERTEX_ACCESS_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+        {
+            return Some(Self::new(&project_id, &location, &token, model));
+        }
+
+        // Fall back to ADC (service account JSON or gcloud default credentials)
+        match Self::with_adc(&project_id, &location, model) {
+            Ok(provider) => Some(provider),
+            Err(e) => {
+                tracing::warn!("Vertex AI ADC not available: {e}");
+                None
+            }
+        }
+    }
+
+    fn build_client() -> Client {
+        Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .expect("failed to build HTTP client")
+    }
+
+    /// Get a valid bearer token, refreshing if needed for ADC.
+    async fn get_token(&self) -> Result<String> {
+        match &self.auth {
+            VertexAuth::Static(token) => Ok(token.clone()),
+            VertexAuth::Adc(cred) => {
+                let token = cred
+                    .access_token()
+                    .await
+                    .map_err(|e| ZeptoError::Provider(format!("Vertex AI token refresh: {e}")))?;
+                Ok(token.token)
+            }
+        }
+    }
+
+    /// Build the full Vertex AI `generateContent` URL.
+    fn api_url(&self, model: &str) -> String {
+        format!(
+            "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent",
+            location = self.location,
+            project = self.project_id,
+            model = model,
+        )
+    }
+
+    /// Build a `generateContent` request body from a slice of [`Message`]s.
+    ///
+    /// The format is identical to the Gemini API: `contents` array with
+    /// `role`/`parts`, optional `systemInstruction`, and `generationConfig`.
+    fn build_messages_body(&self, messages: &[Message], options: &ChatOptions) -> Value {
+        // Separate the system prompt (first System message) from the conversation.
+        let system_prompt = messages
+            .iter()
+            .find(|m| m.role == Role::System)
+            .map(|m| m.content.as_str());
+
+        let contents: Vec<Value> = messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .map(|m| {
+                let gemini_role = match m.role {
+                    Role::Assistant => "model",
+                    _ => "user",
+                };
+                let parts: Vec<Value> = if m.has_images() {
+                    m.content_parts
+                        .iter()
+                        .filter_map(|p| match p {
+                            ContentPart::Text { text } => Some(json!({ "text": text })),
+                            ContentPart::Image { source, media_type } => {
+                                if let ImageSource::Base64 { data } = source {
+                                    Some(json!({
+                                        "inlineData": {
+                                            "mimeType": media_type,
+                                            "data": data
+                                        }
+                                    }))
+                                } else {
+                                    None
+                                }
+                            }
+                        })
+                        .collect()
+                } else {
+                    vec![json!({ "text": &m.content })]
+                };
+                json!({
+                    "role": gemini_role,
+                    "parts": parts
+                })
+            })
+            .collect();
+
+        let mut generation_config = json!({});
+        if let Some(max_tokens) = options.max_tokens {
+            generation_config["maxOutputTokens"] = json!(max_tokens);
+        }
+        if let Some(temp) = options.temperature {
+            generation_config["temperature"] = json!(temp);
+        }
+        if let Some(top_p) = options.top_p {
+            generation_config["topP"] = json!(top_p);
+        }
+
+        let mut body = json!({
+            "contents": contents,
+            "generationConfig": generation_config
+        });
+
+        if let Some(sys) = system_prompt {
+            body["systemInstruction"] = json!({ "parts": [{ "text": sys }] });
+        }
+
+        body
+    }
+}
+
+#[async_trait]
+impl LLMProvider for VertexProvider {
+    async fn chat(
+        &self,
+        messages: Vec<Message>,
+        _tools: Vec<ToolDefinition>,
+        model: Option<&str>,
+        options: ChatOptions,
+    ) -> Result<LLMResponse> {
+        let model = model.unwrap_or(&self.model);
+        let body = self.build_messages_body(&messages, &options);
+        let token = self.get_token().await?;
+
+        debug!("Vertex AI request to model {} in {}", model, self.location);
+
+        let response = self
+            .client
+            .post(self.api_url(model))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ZeptoError::Provider(format!("Vertex AI request failed: {}", e)))?;
+
+        if response.status().is_success() {
+            let json: Value = response.json().await.map_err(|e| {
+                ZeptoError::Provider(format!("Failed to parse Vertex AI response: {}", e))
+            })?;
+
+            // Reuse Gemini's response parsing — the format is identical.
+            let content = GeminiProvider::extract_text(&json).unwrap_or_default();
+            let usage = GeminiProvider::extract_usage(&json);
+
+            let mut llm_response = LLMResponse::text(&content);
+            if let Some(u) = usage {
+                llm_response = llm_response.with_usage(u);
+            }
+            return Ok(llm_response);
+        }
+
+        let status = response.status().as_u16();
+        let error_text = response.text().await.unwrap_or_default();
+
+        // Try to extract a useful message from the Vertex AI error body.
+        let body_msg = serde_json::from_str::<Value>(&error_text)
+            .ok()
+            .and_then(|v| {
+                v["error"]["message"]
+                    .as_str()
+                    .map(|s| format!("Vertex AI API error: {}", s))
+            })
+            .unwrap_or_else(|| format!("Vertex AI API error: {}", error_text));
+
+        Err(ZeptoError::from(parse_provider_error(status, &body_msg)))
+    }
+
+    fn default_model(&self) -> &str {
+        &self.model
+    }
+
+    fn name(&self) -> &str {
+        "vertex"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Message;
+
+    #[test]
+    fn test_constructor_sets_fields() {
+        let provider =
+            VertexProvider::new("my-project", "europe-west1", "token123", "gemini-2.5-pro");
+        assert_eq!(provider.project_id, "my-project");
+        assert_eq!(provider.location, "europe-west1");
+        assert!(matches!(provider.auth, VertexAuth::Static(ref t) if t == "token123"));
+        assert_eq!(provider.model, "gemini-2.5-pro");
+    }
+
+    #[test]
+    fn test_provider_name() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        assert_eq!(provider.name(), "vertex");
+    }
+
+    #[test]
+    fn test_default_model() {
+        let provider = VertexProvider::new("p", "us-central1", "t", "gemini-2.5-pro");
+        assert_eq!(provider.default_model(), "gemini-2.5-pro");
+    }
+
+    #[test]
+    fn test_api_url_construction() {
+        let provider = VertexProvider::new("my-project", "us-central1", "t", "gemini-2.5-flash");
+        let url = provider.api_url("gemini-2.5-flash");
+        assert_eq!(
+            url,
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+        );
+    }
+
+    #[test]
+    fn test_api_url_with_different_location() {
+        let provider = VertexProvider::new("proj-123", "europe-west4", "t", "gemini-2.0-flash");
+        let url = provider.api_url("gemini-2.0-flash");
+        assert!(url.starts_with("https://europe-west4-aiplatform.googleapis.com/"));
+        assert!(url.contains("projects/proj-123"));
+        assert!(url.contains("locations/europe-west4"));
+        assert!(url.ends_with(":generateContent"));
+    }
+
+    #[test]
+    fn test_build_messages_body_basic_text() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        let messages = vec![Message::user("Hello")];
+        let body = provider.build_messages_body(&messages, &ChatOptions::default());
+
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0]["role"], "user");
+        assert_eq!(contents[0]["parts"][0]["text"], "Hello");
+    }
+
+    #[test]
+    fn test_build_messages_body_filters_system_prompt() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        let messages = vec![Message::system("Be helpful"), Message::user("Hi")];
+        let body = provider.build_messages_body(&messages, &ChatOptions::default());
+
+        // System message should NOT appear in contents.
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0]["role"], "user");
+
+        // System message should be lifted to systemInstruction.
+        assert_eq!(body["systemInstruction"]["parts"][0]["text"], "Be helpful");
+    }
+
+    #[test]
+    fn test_build_messages_body_maps_assistant_to_model() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        let messages = vec![Message::user("Hi"), Message::assistant("Hello!")];
+        let body = provider.build_messages_body(&messages, &ChatOptions::default());
+
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0]["role"], "user");
+        assert_eq!(contents[1]["role"], "model");
+    }
+
+    #[test]
+    fn test_build_messages_body_generation_config() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        let options = ChatOptions::new()
+            .with_max_tokens(1024)
+            .with_temperature(0.5)
+            .with_top_p(0.75);
+        let body = provider.build_messages_body(&[Message::user("Hi")], &options);
+
+        let gen_config = &body["generationConfig"];
+        assert_eq!(gen_config["maxOutputTokens"], 1024);
+        assert_eq!(gen_config["temperature"], 0.5);
+        assert_eq!(gen_config["topP"], 0.75);
+    }
+
+    #[test]
+    fn test_extract_text_reuses_gemini_parser() {
+        let response = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        { "text": "thinking...", "thought": true },
+                        { "text": "Final answer" }
+                    ]
+                }
+            }]
+        });
+        let text = GeminiProvider::extract_text(&response);
+        assert_eq!(text.as_deref(), Some("Final answer"));
+    }
+
+    #[test]
+    fn test_extract_usage_reuses_gemini_parser() {
+        let response = serde_json::json!({
+            "candidates": [{ "content": { "parts": [{ "text": "hi" }] } }],
+            "usageMetadata": {
+                "promptTokenCount": 42,
+                "candidatesTokenCount": 10,
+                "totalTokenCount": 52
+            }
+        });
+        let usage = GeminiProvider::extract_usage(&response);
+        assert!(usage.is_some());
+        let u = usage.unwrap();
+        assert_eq!(u.prompt_tokens, 42);
+        assert_eq!(u.completion_tokens, 10);
+        assert_eq!(u.total_tokens, 52);
+    }
+
+    #[test]
+    fn test_no_system_instruction_when_no_system_message() {
+        let provider = VertexProvider::new("p", "us-central1", "t", DEFAULT_VERTEX_MODEL);
+        let messages = vec![Message::user("Hello")];
+        let body = provider.build_messages_body(&messages, &ChatOptions::default());
+        assert!(body.get("systemInstruction").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_token_static() {
+        let provider = VertexProvider::new("p", "us-central1", "my-token", "m");
+        let token = provider.get_token().await.unwrap();
+        assert_eq!(token, "my-token");
+    }
+
+    #[test]
+    fn test_static_auth_debug_redacted() {
+        let auth = VertexAuth::Static("secret".to_string());
+        let debug = format!("{:?}", auth);
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("REDACTED"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #363

Adds first-class Google Vertex AI provider for Gemini models via regional endpoint with enterprise-grade auth.

- **Auth priority:** `VERTEX_ACCESS_TOKEN` env var (static bearer) → `google-cloud-auth` ADC (auto-refresh via service account or `gcloud auth application-default login`)
- **Reuses** GeminiProvider response parsing (`extract_text`, `extract_usage`) — no duplicated logic
- **Config:** `providers.vertex.api_key` (GCP project ID), `providers.vertex.api_base` (location)
- **Env overrides:** `ZEPTOCLAW_PROVIDERS_VERTEX_{API_KEY,API_BASE,MODEL}`

Split from #364 — Vertex provider only. R8r bridge and system prompt changes will be separate PRs.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 14 new Vertex unit tests pass
- [x] Full lib suite: 3353 passed, 0 failed
- [ ] Manual: `provider status` shows vertex when configured
- [ ] Manual: `agent -m "Hello"` works with vertex provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Vertex AI as a new provider for chat operations
  * Vertex AI configuration available via environment variables for API key, endpoint, and model selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->