### PR TITLE
fix(onboard): provider-first flow with filtered model selection

### DIFF
--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -233,7 +233,7 @@ async fn configure_model_for_provider(config: &mut Config, provider: &str) -> Re
 
     println!();
     println!("Which model would you like to use?");
-    print!("{}", format_model_menu(&models, 30));
+    print!("{}", format_model_menu(&models, models.len()));
     println!();
     print!("Choice [1]: ");
     io::stdout().flush()?;


### PR DESCRIPTION
## Summary

Closes #452

Reworked onboard flow from "configure all API keys → pick model" to **pick provider → enter API key → pick model**.

### Before
1. Multi-select providers (1,2,3,4)
2. Enter API keys for all selected
3. Ask "which is your default?" (confusing)
4. Show 128 unfiltered models, truncated to 15
5. Default [1] = babbage-002

### After
1. Pick one provider (Anthropic / OpenAI / OpenRouter)
2. Enter API key
3. Fetch models → filter non-chat → sort popular first → show 30
4. Default [1] = gpt-4.1 or claude-sonnet (most relevant)
5. Offer to add another provider

### Details
- Filter out non-chat models (babbage, dall-e, whisper, embeddings, TTS, etc.)
- Sort popular models first (gpt-4.1, gpt-4o, o3, claude, gemini)
- Show 30 instead of 15
- 3 new tests for filter and sort logic

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 6 onboard tests pass (3 new)
- [ ] Manual: `zeptoclaw onboard` shows new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified onboarding: configure one primary provider first, then set up its API key and choose a model.
  * Optional prompt to add additional providers after initial setup, repeating API-key + model selection per provider.
  * Better model discovery: excludes non-chat models and sorts choices to surface more relevant models; full model list shown.
* **Tests**
  * Added unit tests for model filtering and sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->