### PR TITLE
fix(providers): skip Claude CLI import when anthropic config is null

### DIFF
--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -494,7 +494,7 @@ fn resolve_credential(
     // Last-resort fallback: import from Claude CLI (Keychain / ~/.claude.json).
     // Disabled in test builds to avoid picking up real credentials from the host.
     #[cfg(not(test))]
-    if result.is_none() && spec.name == "anthropic" {
+    if result.is_none() && spec.name == "anthropic" && provider_config.is_some() {
         if let Some(token_set) = crate::auth::claude_import::read_claude_credentials() {
             static WARN_ONCE: std::sync::Once = std::sync::Once::new();
             WARN_ONCE.call_once(|| {


### PR DESCRIPTION
## Summary
- When `"anthropic": null` in config, the Claude CLI token import fallback still activated because `resolve_credential()` only checked `spec.name == "anthropic"` without verifying `provider_config` is present
- This caused a model-provider mismatch error when the default model is non-Claude (e.g. `gpt-5.4`)
- One-line fix: add `&& provider_config.is_some()` guard to the CLI import fallback

Closes #454

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo nextest run --lib` — 3353 tests pass
- [ ] Manual: set `"anthropic": null` + non-Claude default model, verify gateway starts without mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Anthropic credential import behavior to restrict fallback credential resolution to scenarios where an explicit Anthropic provider configuration is present. Previously, the fallback mechanism could activate unnecessarily even without a provider configuration. This improves the reliability and predictability of credential handling for the Anthropic provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->