### PR TITLE
fix(runtime): wire up Landlock workspace access

### DIFF
--- a/src/runtime/landlock.rs
+++ b/src/runtime/landlock.rs
@@ -56,8 +56,9 @@ impl ContainerRuntime for LandlockRuntime {
         let ll_config = self.config.clone();
         let command = command.to_string();
 
+        let workspace = config.workdir.clone();
         tokio::task::spawn_blocking(move || {
-            execute_with_landlock(&command, &config_clone, &ll_config)
+            execute_with_landlock(&command, &config_clone, &ll_config, workspace.as_deref())
         })
         .await
         .map_err(|e| RuntimeError::ExecutionFailed(format!("spawn_blocking join error: {e}")))?
@@ -74,6 +75,7 @@ fn execute_with_landlock(
     _command: &str,
     _config: &ContainerConfig,
     _ll_config: &LandlockConfig,
+    _workspace: Option<&std::path::Path>,
 ) -> RuntimeResult<CommandOutput> {
     Err(RuntimeError::NotAvailable(
         "Recompile with --features sandbox-landlock to use the Landlock runtime.".to_string(),
@@ -85,8 +87,9 @@ fn execute_with_landlock(
     command: &str,
     config: &ContainerConfig,
     ll_config: &LandlockConfig,
+    workspace: Option<&std::path::Path>,
 ) -> RuntimeResult<CommandOutput> {
-    execute_with_landlock_inner(command, config, ll_config)
+    execute_with_landlock_inner(command, config, ll_config, workspace)
 }
 
 /// Inner implementation, only compiled when the feature is enabled.
@@ -95,6 +98,7 @@ fn execute_with_landlock_inner(
     command: &str,
     config: &ContainerConfig,
     ll_config: &LandlockConfig,
+    workspace: Option<&std::path::Path>,
 ) -> RuntimeResult<CommandOutput> {
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
@@ -114,15 +118,16 @@ fn execute_with_landlock_inner(
     // Apply Landlock in the child process (after fork, before exec).
     // This ensures the parent ZeptoClaw process is never restricted.
     let ll_config_clone = ll_config.clone();
+    let workspace_clone = workspace.map(|p| p.to_path_buf());
     // SAFETY: We only call async-signal-safe operations in the pre_exec closure.
     // `landlock::Ruleset` operations use only synchronous syscalls (landlock_create_ruleset,
     // landlock_add_rule, landlock_restrict_self, prctl) which are async-signal-safe.
     // PathFd::new calls open() which is also async-signal-safe.
     unsafe {
         cmd.pre_exec(move || {
-            apply_landlock_rules_in_child(&ll_config_clone).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::PermissionDenied, e.to_string())
-            })
+            apply_landlock_rules_in_child(&ll_config_clone, workspace_clone.as_deref()).map_err(
+                |e| std::io::Error::new(std::io::ErrorKind::PermissionDenied, e.to_string()),
+            )
         });
     }
 
@@ -153,9 +158,14 @@ fn execute_with_landlock_inner(
 /// Apply Landlock filesystem rules to the current process.
 ///
 /// Called inside the child process via `pre_exec`. Restricts filesystem access
-/// based on the configured read/write directory allowlists.
+/// based on the configured read/write directory allowlists. When a workspace
+/// path is provided, it is added to the read/write allowlists according to
+/// `allow_read_workspace` / `allow_write_workspace`.
 #[cfg(all(target_os = "linux", feature = "sandbox-landlock"))]
-fn apply_landlock_rules_in_child(config: &LandlockConfig) -> Result<(), RuntimeError> {
+fn apply_landlock_rules_in_child(
+    config: &LandlockConfig,
+    workspace: Option<&std::path::Path>,
+) -> Result<(), RuntimeError> {
     use landlock::{
         Access, AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr,
         RulesetStatus, ABI,
@@ -171,9 +181,22 @@ fn apply_landlock_rules_in_child(config: &LandlockConfig) -> Result<(), RuntimeE
         .create()
         .map_err(|e| RuntimeError::ExecutionFailed(format!("Landlock create error: {e}")))?;
 
+    // Build effective directory lists, adding workspace when configured.
+    let mut read_dirs: Vec<String> = config.fs_read_dirs.clone();
+    let mut write_dirs: Vec<String> = config.fs_write_dirs.clone();
+    if let Some(ws) = workspace {
+        let ws_str = ws.to_string_lossy().to_string();
+        if config.allow_read_workspace && !read_dirs.contains(&ws_str) {
+            read_dirs.push(ws_str.clone());
+        }
+        if config.allow_write_workspace && !write_dirs.contains(&ws_str) {
+            write_dirs.push(ws_str);
+        }
+    }
+
     // Grant read access to configured directories.
     let mut ruleset = ruleset;
-    for dir in &config.fs_read_dirs {
+    for dir in &read_dirs {
         if let Ok(fd) = PathFd::new(dir) {
             ruleset = match ruleset.add_rule(PathBeneath::new(fd, AccessFs::from_read(abi))) {
                 Ok(rs) => rs,
@@ -188,7 +211,7 @@ fn apply_landlock_rules_in_child(config: &LandlockConfig) -> Result<(), RuntimeE
     }
 
     // Grant full access (read + write) to configured write directories.
-    for dir in &config.fs_write_dirs {
+    for dir in &write_dirs {
         if let Ok(fd) = PathFd::new(dir) {
             ruleset = match ruleset.add_rule(PathBeneath::new(fd, AccessFs::from_all(abi))) {
                 Ok(rs) => rs,


### PR DESCRIPTION
## Summary

When enabling `runtime_type: "landlock"` to sandbox shell commands, the agent's workspace directory was inaccessible — even though `allow_read_workspace` and `allow_write_workspace` defaulted to `true` in the config.

**User story:** A user enables Landlock sandboxing to restrict what shell commands can touch on the filesystem. They expect the agent's workspace to still be readable and writable (since the config says so). Instead, every shell command that tries to write to the workspace gets "permission denied". The `write_file` tool works fine (it runs in the parent process), but shell redirects like `echo test > workspace/file.txt` fail. The user has to manually add the workspace path to `fs_write_dirs` as a workaround.

**Root cause:** `allow_read_workspace` and `allow_write_workspace` were defined in `LandlockConfig` and defaulted to `true`, but `apply_landlock_rules_in_child()` never received the workspace path — so the flags were dead config.

**Fix:** Pass the workspace path (from `ContainerConfig.workdir`) through the execution chain into the Landlock rule builder. When the flags are set, the workspace is added to the effective read/write directory lists before the ruleset is applied.

Also includes the prior commit fixing `add_rule()` ownership — it takes `self` by value, so the ruleset must be reassigned each iteration (previously hidden behind the feature gate).

## Test plan

- [x] `cargo test --lib --features sandbox-landlock -- landlock` — 10 tests pass
- [x] `cargo clippy --features sandbox-landlock -- -D warnings` — clean
- [ ] Manual: enable Landlock, verify shell can write to workspace
- [ ] Manual: verify shell cannot write outside allowed dirs

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landlock runtime now supports optional workspace paths with conditional read and write directory access control.

* **Bug Fixes**
  * Landlock rule application failures now properly report errors instead of silently continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->