### PR TITLE
chore(ci): bump binary size limit to 12 MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_TERM_QUIET: "true" # F.I.R.S.T. principle (only print failures, not test names)
   RUSTFLAGS: -Dwarnings
-  BINARY_SIZE_LIMIT_MB: 11
+  BINARY_SIZE_LIMIT_MB: 12
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The release binary grew to **11.2 MB** after the recent batch of dependency bumps and the OpenAI-compatible serve tool-call additions, tripping the 11 MB CI guardrail and turning `main` red.

Bump `BINARY_SIZE_LIMIT_MB` from 11 to 12 to unblock `main`. We can look at trimming bloat (axum/panel feature audit, dead deps, strip-debug review) in a follow-up.

## Test plan

- [x] CI binary-size job should now pass (failing log: `Binary size: 11.2 MB (limit: 11 MB)`)
- [ ] Confirm green CI on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration thresholds to accommodate project growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->