### PR TITLE
chore(bloat): gate vertex provider + drop zopfli encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7344,7 +7344,6 @@ dependencies = [
  "indexmap 2.13.0",
  "memchr",
  "typed-path",
- "zopfli",
 ]
 
 [[package]]
@@ -7358,15 +7357,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,8 +165,11 @@ base64 = "0.22"
 tempfile = "3.10"
 # Secure password input (hidden terminal echo)
 rpassword = "7.3"
-# Zip archive extraction for ClawHub skill installs
-zip = { version = "8", default-features = false, features = ["deflate"] }
+# Zip archive extraction for ClawHub skill installs.
+# Pick the flate2+zlib-rs backend explicitly — the umbrella "deflate" feature also
+# pulls zopfli (a high-ratio compression *encoder*) which we never use (read-only
+# zip consumption). Dropping zopfli saves ~100 KiB of code + tables.
+zip = { version = "8", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 # =============================================================================
 # EMAIL CHANNEL (optional — feature-gated behind "channel-email")
@@ -247,7 +250,16 @@ jsonwebtoken = { version = "10", optional = true, features = ["aws_lc_rs"] }
 # Password hashing for panel password auth mode
 bcrypt = { version = "0.19", optional = true }
 unicode-normalization = "0.1.25"
-google-cloud-auth = { version = "1.7.0", default-features = false }
+
+# =============================================================================
+# VERTEX PROVIDER (optional — feature-gated behind "provider-vertex")
+# =============================================================================
+# Google Cloud ADC / access-token credentials for Vertex AI Gemini.
+# Only pulled in when the `provider-vertex` feature is enabled; otherwise the
+# VertexProvider module is cfg'd out entirely and every config entry referencing
+# `providers.vertex` will surface a clear runtime error asking users to rebuild
+# with `--features provider-vertex`.
+google-cloud-auth = { version = "1.7.0", default-features = false, optional = true }
 
 # USB device enumeration — only on platforms nusb supports (Linux, macOS, Windows)
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
@@ -297,6 +309,9 @@ android = []
 sandbox-landlock   = ["dep:landlock"]
 sandbox-firejail   = []
 sandbox-bubblewrap = []
+# Vertex AI provider (Google Cloud Gemini via ADC / access token)
+# Pulls in google-cloud-auth and its transitive google-cloud-gax / google-cloud-rpc stack.
+provider-vertex = ["dep:google-cloud-auth"]
 # Google Workspace tools (Gmail + Calendar) via gogcli-rs
 google = ["dep:gog-gmail", "dep:gog-calendar", "dep:gog-auth", "dep:gog-core"]
 # Control panel API server + dashboard (axum, JWT, bcrypt)

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -95,21 +95,35 @@ pub async fn provider_from_runtime_selection(
             Some(Box::new(provider))
         }
         "vertex" => {
-            // For Vertex: api_key holds the GCP project ID, api_base holds the location.
-            // Auth: VERTEX_ACCESS_TOKEN (static) → ADC (auto-refresh via google-cloud-auth).
-            let api_key = if selection.api_key.is_empty() {
+            #[cfg(feature = "provider-vertex")]
+            {
+                // For Vertex: api_key holds the GCP project ID, api_base holds the location.
+                // Auth: VERTEX_ACCESS_TOKEN (static) → ADC (auto-refresh via google-cloud-auth).
+                let api_key = if selection.api_key.is_empty() {
+                    None
+                } else {
+                    Some(selection.api_key.as_str())
+                };
+                let api_base = selection.api_base.as_deref().filter(|b| !b.is_empty());
+                crate::providers::vertex::VertexProvider::from_config(
+                    api_key,
+                    api_base,
+                    configured_model,
+                )
+                .await
+                .map(|p| Box::new(p) as Box<dyn LLMProvider>)
+            }
+            #[cfg(not(feature = "provider-vertex"))]
+            {
+                let _ = configured_model; // silence unused-var warning
+                tracing::warn!(
+                    "Vertex provider is configured but this build was compiled without the \
+                     `provider-vertex` feature. Rebuild with `cargo build --release --features \
+                     provider-vertex` (or `cargo install zeptoclaw --features provider-vertex`) \
+                     to enable Vertex AI."
+                );
                 None
-            } else {
-                Some(selection.api_key.as_str())
-            };
-            let api_base = selection.api_base.as_deref().filter(|b| !b.is_empty());
-            crate::providers::vertex::VertexProvider::from_config(
-                api_key,
-                api_base,
-                configured_model,
-            )
-            .await
-            .map(|p| Box::new(p) as Box<dyn LLMProvider>)
+            }
         }
         _ => None,
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub mod retry;
 pub mod rotation;
 pub mod structured;
 mod types;
+#[cfg(feature = "provider-vertex")]
 pub mod vertex;
 
 /// Provider IDs currently supported by the runtime.
@@ -81,6 +82,7 @@ pub use structured::{validate_json_response, OutputFormat};
 pub use types::{
     ChatOptions, LLMProvider, LLMResponse, LLMToolCall, StreamEvent, ToolDefinition, Usage,
 };
+#[cfg(feature = "provider-vertex")]
 pub use vertex::VertexProvider;
 
 /// Parse an HTTP status code and response body into a structured [`ProviderError`].


### PR DESCRIPTION
## Summary

Phase 1 of the binary diet. Two independent, low-risk wins:

**1. Gate `VertexProvider` behind new `provider-vertex` feature**
- `google-cloud-auth` (+ transitive `google-cloud-gax`, `google-cloud-rpc`, `google-cloud-wkt`) is now an optional dep, off by default
- \`src/providers/vertex.rs\` cfg'd out when feature is off
- The \`\"vertex\" =>\` arm in \`kernel::provider::provider_from_runtime_selection\` emits a clear \`tracing::warn!\` pointing users at \`cargo install zeptoclaw --features provider-vertex\`
- Config types, registry entries, and \`RUNTIME_SUPPORTED_PROVIDERS\` are untouched — configs referencing \`providers.vertex\` still parse, they just fail to instantiate at runtime with a helpful message
- ⚠️ **Breaking for Vertex AI users**: they need \`--features provider-vertex\` on rebuild

**2. Drop \`zopfli\` from \`zip\` features**
- Switched from \`"deflate"\` umbrella (which pulls \`deflate-flate2-zlib-rs\` *and* \`deflate-zopfli\`) to \`"deflate-flate2-zlib-rs"\` explicitly
- Zopfli is a high-ratio compression *encoder*; we only read zips (skill archives, docx extraction), never write them — the encoder + its precomputed tables were pure dead code

## Measurements (macOS aarch64, release, \`strip = true\`)

| | Size | Delta |
|---|---|---|
| \`main\` (control) | 7,636,192 B (7.28 MiB) | — |
| \`chore/binary-diet-phase1\` | 7,316,480 B (6.98 MiB) | **−319,712 B (−4.2%)** |

Linux CI binaries are consistently ~50% larger than macOS Mach-O for the same code, so the Linux CI binary should drop ~500–800 KiB from the current 11.2 MB. The \`BINARY_SIZE_LIMIT_MB: 12\` headroom from #504 stays for now; a follow-up can tighten it once we see the actual Linux delta post-merge.

## Validation

- \`cargo check --release\` (default features)
- \`cargo check --release --features provider-vertex\` (feature on)
- \`cargo check --no-default-features\` (CI feature-matrix parity)
- \`cargo fmt --check\`, \`cargo clippy --release -- -D warnings\`
- \`cargo nextest run --lib\` → 3407 passed
- \`cargo test --doc\` → 128 passed

## Test plan

- [x] Default build compiles, tests pass
- [x] Vertex feature still compiles when enabled
- [x] \`--no-default-features\` still compiles
- [ ] Post-merge: verify Linux CI binary-size drop in main CI run

## Follow-up phases (separate PRs)

- Phase 2: Gate \`channels/telegram.rs\` + teloxide behind \`channel-telegram\` (~500 KiB - 1 MB)
- Phase 3: Gate \`tools/web.rs\` + scraper behind \`tool-web-fetch\` (~130 KiB)
- Phase 4: Full per-channel feature matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Vertex provider is now optional via the `provider-vertex` feature flag, allowing users to exclude it at build time to reduce dependencies.
  * Updated compression library backend configuration for more explicit dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->