### PR TITLE
chore(ci): tighten binary size limit 12 → 11 MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_TERM_QUIET: "true" # F.I.R.S.T. principle (only print failures, not test names)
   RUSTFLAGS: -Dwarnings
-  BINARY_SIZE_LIMIT_MB: 12
+  BINARY_SIZE_LIMIT_MB: 11
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Post-#505 diet, the v0.9.2 release binary landed at **10.66 MB** on Linux x86_64 (the target CI measures). Tighten the guardrail back down from the 12 MB headroom we added in #504 so the next accidental bloat gets caught early instead of sliding under the inflated limit.

11 MB gives ~340 KiB of headroom vs the current 10.66 MB — enough to absorb small dependency bumps without retriggering churn, but tight enough to actually guard against regressions.

## Before / after

| | Limit | Actual (Linux x86_64) | Headroom |
|---|---|---|---|
| After #504 (pre-diet) | 12 MB | 11.2 MB | 800 KiB |
| After #505 (diet landed) | 12 MB | 10.66 MB | 1.34 MB |
| **This PR** | **11 MB** | 10.66 MB | **340 KiB** |

## Test plan

- [x] Binary-size job is gated to push-to-main so this PR itself won't exercise it (SKIPPED in PR checks)
- [ ] Post-merge: main CI run should report \`Binary size: 10.6 MB (limit: 11 MB)\` and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced binary size limit threshold in continuous integration pipeline from 12MB to 11MB, enforcing stricter compilation constraints on future builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->