### PR TITLE
[codex] fix telegram config compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Project-level guidance for coding agents working in this repository.
 - Channel panic isolation: Slack/Discord/Webhook/WhatsApp/WhatsApp Web/WhatsApp Cloud/Lark/Email/MQTT/Serial spawned tasks are wrapped with `catch_unwind` and panic logging
 - Webhook auth hardening: generic webhook supports optional HMAC-SHA256 body signatures plus fixed server-side sender/chat identity by default (`trust_payload_identity` is an explicit legacy escape hatch); WhatsApp Cloud verifies `X-Hub-Signature-256` when `app_secret` is configured
 - Telegram allowlist hardening: numeric user IDs are the safe default for new setups; legacy username matching remains available only through `channels.telegram.allow_usernames` for compatibility and emits warnings when non-numeric allowlist entries are present
+- Telegram config compatibility: `channels.telegram` accepts legacy `bot_token`, `allowed_senders`, and `allowed_chats` keys, and auto-enables when `enabled` is omitted but a Telegram token is present
 - Email allowlist limitation surfaced: `channels.email.allowed_senders` matches the parsed `From` header only and now emits config/runtime warnings so authenticated-mail enforcement is pushed upstream
 - Telegram outbound formatting: sends HTML parse mode with `||spoiler||` → `<tg-spoiler>` conversion
 - Discord outbound delivery: supports reply references and thread-create metadata (`discord_thread_*`) in `OutboundMessage`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ For detailed module docs see `docs/claude/architecture.md`.
 - Model-driven provider inference treats vendor-prefixed gateway IDs like `anthropic/...` as OpenRouter models only when OpenRouter is actually available, and live provider model discovery now carries `api-version` while normalizing Azure deployment bases to `/openai/models`.
 - The OpenAI-compatible `/v1/chat/completions` serve path forwards request tools, returns OpenAI-style tool-call payloads for assistant/tool messages, and the default provider streaming adapter now emits a text delta plus tool-call events before `Done` so non-native streaming providers are not silently flattened.
 - The serve API only accepts omitted, `null`, or `"auto"` for `tool_choice`; unsupported values are rejected with `400` instead of being ignored.
+- Telegram config parsing accepts legacy `bot_token`, `allowed_senders`, and `allowed_chats` keys; if `enabled` is omitted but a Telegram token is present, the channel now auto-enables on load.
 - `shell` tool output is truncated at 2,000 lines / 50KB before it reaches the model context.
 - `grep` reports subprocess failures instead of collapsing them into "No matches found".
 - `edit_file` rejects empty `old_text` and accepts optional `expected_replacements` to guard exact-match edits.

--- a/landing/zeptoclaw/docs/src/content/docs/concepts/channels.md
+++ b/landing/zeptoclaw/docs/src/content/docs/concepts/channels.md
@@ -47,7 +47,7 @@ The Telegram channel uses the Bot API with long polling. Configure it with:
   "channels": {
     "telegram": {
       "enabled": true,
-      "bot_token": "123456:ABC..."
+      "token": "123456:ABC..."
     }
   }
 }
@@ -55,7 +55,7 @@ The Telegram channel uses the Bot API with long polling. Configure it with:
 
 Or via environment variable:
 ```bash
-export ZEPTOCLAW_CHANNELS_TELEGRAM_BOT_TOKEN=123456:ABC...
+export ZEPTOCLAW_CHANNELS_TELEGRAM_TOKEN=123456:ABC...
 ```
 
 ## Slack
@@ -176,9 +176,9 @@ All channels support the `deny_by_default` config option for sender allowlists. 
   "channels": {
     "telegram": {
       "enabled": true,
-      "bot_token": "123456:ABC...",
+      "token": "123456:ABC...",
       "deny_by_default": true,
-      "allowed_senders": ["user_id_1", "user_id_2"]
+      "allow_from": ["123456789", "987654321"]
     }
   }
 }

--- a/landing/zeptoclaw/docs/src/content/docs/concepts/channels.md
+++ b/landing/zeptoclaw/docs/src/content/docs/concepts/channels.md
@@ -56,6 +56,7 @@ The Telegram channel uses the Bot API with long polling. Configure it with:
 Or via environment variable:
 ```bash
 export ZEPTOCLAW_CHANNELS_TELEGRAM_TOKEN=123456:ABC...
+export ZEPTOCLAW_CHANNELS_TELEGRAM_ENABLED=true
 ```
 
 ## Slack

--- a/landing/zeptoclaw/docs/src/content/docs/guides/security.md
+++ b/landing/zeptoclaw/docs/src/content/docs/guides/security.md
@@ -173,7 +173,7 @@ All channels support deny-by-default sender allowlists:
   "channels": {
     "telegram": {
       "enabled": true,
-      "bot_token": "...",
+      "token": "...",
       "deny_by_default": true,
       "allow_from": ["123456789"]
     }

--- a/landing/zeptoclaw/docs/src/content/docs/reference/configuration.md
+++ b/landing/zeptoclaw/docs/src/content/docs/reference/configuration.md
@@ -48,7 +48,7 @@ ZeptoClaw is configured via `~/.zeptoclaw/config.json`. All fields have sensible
   "channels": {
     "telegram": {
       "enabled": true,
-      "bot_token": "123456:ABC..."
+      "token": "123456:ABC..."
     },
     "slack": {
       "enabled": false,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1846,6 +1846,21 @@ mod tests {
     }
 
     #[test]
+    fn test_telegram_channel_config_does_not_enable_whitespace_token() {
+        let json = r#"{
+            "channels": {
+                "telegram": {
+                    "token": "   "
+                }
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let telegram = config.channels.telegram.unwrap();
+        assert!(!telegram.enabled);
+        assert_eq!(telegram.token, "");
+    }
+
+    #[test]
     fn test_provider_configs() {
         let json = r#"{
             "providers": {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1811,6 +1811,41 @@ mod tests {
     }
 
     #[test]
+    fn test_telegram_channel_config_accepts_legacy_keys_and_infers_enabled() {
+        let json = r#"{
+            "channels": {
+                "telegram": {
+                    "bot_token": "bot123:ABC",
+                    "allowed_chats": "123456789"
+                }
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let telegram = config.channels.telegram.unwrap();
+        assert!(telegram.enabled);
+        assert_eq!(telegram.token, "bot123:ABC");
+        assert_eq!(telegram.allow_from, vec!["123456789"]);
+    }
+
+    #[test]
+    fn test_telegram_channel_config_respects_explicit_disabled_flag() {
+        let json = r#"{
+            "channels": {
+                "telegram": {
+                    "enabled": false,
+                    "bot_token": "bot123:ABC",
+                    "allowed_senders": ["123456789", "987654321"]
+                }
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let telegram = config.channels.telegram.unwrap();
+        assert!(!telegram.enabled);
+        assert_eq!(telegram.token, "bot123:ABC");
+        assert_eq!(telegram.allow_from, vec!["123456789", "987654321"]);
+    }
+
+    #[test]
     fn test_provider_configs() {
         let json = r#"{
             "providers": {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -3,6 +3,7 @@
 //! This module defines all configuration structs used throughout the framework.
 //! All types implement serde traits for JSON serialization and have sensible defaults.
 
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -1142,12 +1143,40 @@ fn default_telegram_reactions() -> bool {
     true
 }
 
+fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    let value = Option::<StringOrVec>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(StringOrVec::One(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Vec::new()
+            } else {
+                vec![trimmed.to_string()]
+            }
+        }
+        Some(StringOrVec::Many(values)) => values
+            .into_iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect(),
+        None => Vec::new(),
+    })
+}
+
 /// Telegram channel configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TelegramConfig {
     /// Whether the channel is enabled
-    #[serde(default)]
     pub enabled: bool,
     /// Bot token from BotFather
     pub token: String,
@@ -1179,6 +1208,45 @@ impl Default for TelegramConfig {
             allow_usernames: default_telegram_allow_usernames(),
             reactions: default_telegram_reactions(),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for TelegramConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Default)]
+        #[serde(default)]
+        struct RawTelegramConfig {
+            enabled: Option<bool>,
+            #[serde(alias = "bot_token")]
+            token: String,
+            #[serde(
+                default,
+                alias = "allowed_senders",
+                alias = "allowed_chats",
+                deserialize_with = "deserialize_string_or_vec"
+            )]
+            allow_from: Vec<String>,
+            #[serde(default)]
+            deny_by_default: bool,
+            #[serde(default = "default_telegram_allow_usernames")]
+            allow_usernames: bool,
+            #[serde(default = "default_telegram_reactions")]
+            reactions: bool,
+        }
+
+        let raw = RawTelegramConfig::deserialize(deserializer)?;
+        let enabled = raw.enabled.unwrap_or(!raw.token.is_empty());
+        Ok(Self {
+            enabled,
+            token: raw.token,
+            allow_from: raw.allow_from,
+            deny_by_default: raw.deny_by_default,
+            allow_usernames: raw.allow_usernames,
+            reactions: raw.reactions,
+        })
     }
 }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1143,6 +1143,11 @@ fn default_telegram_reactions() -> bool {
     true
 }
 
+/// Deserialize a Telegram allowlist from either a single string or a string array.
+///
+/// This keeps compatibility with legacy config examples that used a single
+/// `allowed_chats` value while normalizing the stored representation to
+/// `Vec<String>`.
 fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
@@ -1212,6 +1217,11 @@ impl Default for TelegramConfig {
 }
 
 impl<'de> Deserialize<'de> for TelegramConfig {
+    /// Deserialize Telegram config with legacy field aliases and inferred enablement.
+    ///
+    /// Supports `bot_token`, `allowed_senders`, and `allowed_chats` for backward
+    /// compatibility. When `enabled` is omitted, the channel auto-enables if a
+    /// Telegram token is present.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1248,10 +1248,11 @@ impl<'de> Deserialize<'de> for TelegramConfig {
         }
 
         let raw = RawTelegramConfig::deserialize(deserializer)?;
-        let enabled = raw.enabled.unwrap_or(!raw.token.is_empty());
+        let token = raw.token.trim().to_string();
+        let enabled = raw.enabled.unwrap_or(!token.is_empty());
         Ok(Self {
             enabled,
-            token: raw.token,
+            token,
             allow_from: raw.allow_from,
             deny_by_default: raw.deny_by_default,
             allow_usernames: raw.allow_usernames,


### PR DESCRIPTION
## Summary
- restore Telegram config compatibility for legacy keys used in the issue report and published examples
- infer `channels.telegram.enabled = true` when a Telegram token is present and `enabled` is omitted
- update docs and agent handoff notes to reflect the supported Telegram config fields

## Root Cause
The runtime expected `channels.telegram.token` and `allow_from`, but issue #522 and repository docs still showed legacy keys such as `bot_token` and `allowed_chats`. Configs using those keys deserialized into a disabled Telegram channel.

## Validation
- cargo test
- cargo clippy -- -D warnings
- cargo fmt --check

Closes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Telegram config keys renamed: bot_token → token; allowed_senders/allowed_chats → allow_from. Legacy keys remain supported and allow_from accepts a single ID or a list.
  * Env var renamed: ZEPTOCLAW_CHANNELS_TELEGRAM_BOT_TOKEN → ZEPTOCLAW_CHANNELS_TELEGRAM_TOKEN.
  * Telegram channel auto-enables when a token is present and enabled is omitted.

* **Documentation**
  * Updated guides, reference, and examples (including numeric sender ID examples and an enabled=true example).

* **Tests**
  * Added coverage verifying legacy key support and enabled inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->