### PR TITLE
feat(tools): add SHA256 verification path for skill downloads

### DIFF
--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -156,6 +156,24 @@ fn normalize_sha256(digest: &str) -> crate::error::Result<String> {
     Ok(normalized)
 }
 
+fn resolve_verified_sha256(
+    requested_sha256: Option<String>,
+    response_sha256: Option<String>,
+) -> crate::error::Result<Option<String>> {
+    match (requested_sha256, response_sha256) {
+        (Some(requested), Some(response)) if requested != response => {
+            Err(crate::error::ZeptoError::SecurityViolation(format!(
+                "Skill archive SHA-256 digest conflict: provided {}, response header {}",
+                requested, response
+            )))
+        }
+        (Some(requested), Some(_)) => Ok(Some(requested)),
+        (Some(requested), None) => Ok(Some(requested)),
+        (None, Some(response)) => Ok(Some(response)),
+        (None, None) => Ok(None),
+    }
+}
+
 /// Check whether `host` is in the allowed-hosts bypass list (case-insensitive).
 fn is_allowed_host(host: &str, allowed_hosts: &[String]) -> bool {
     let host_lower = host.to_ascii_lowercase();
@@ -397,7 +415,7 @@ impl ClawHubRegistry {
             .map(normalize_sha256)
             .transpose()?;
 
-        let verified_sha256 = requested_sha256.or(response_sha256);
+        let verified_sha256 = resolve_verified_sha256(requested_sha256, response_sha256)?;
 
         // Reject archives that are larger than 50 MB before buffering.
         if let Some(content_length) = resp.content_length() {
@@ -674,6 +692,26 @@ mod tests {
             "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
         )
         .is_err());
+    }
+
+    #[test]
+    fn test_resolve_verified_sha256_accepts_matching_sources() {
+        let digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let resolved = resolve_verified_sha256(Some(digest.to_string()), Some(digest.to_string()))
+            .expect("matching digests should be accepted");
+        assert_eq!(resolved.as_deref(), Some(digest));
+    }
+
+    #[test]
+    fn test_resolve_verified_sha256_rejects_conflicting_sources() {
+        let requested = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let response = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let err = resolve_verified_sha256(Some(requested.to_string()), Some(response.to_string()))
+            .expect_err("conflicting digests must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("digest conflict"));
+        assert!(msg.contains(requested));
+        assert!(msg.contains(response));
     }
 
     // -------------------------------------------------------------------------

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::tools::web::{is_blocked_host, resolve_and_check_host};
 
@@ -25,9 +26,21 @@ pub struct SkillSearchResult {
     pub summary: String,
     /// Published version string (e.g. "1.0.0").
     pub version: String,
+    /// Optional published SHA-256 digest for the downloadable skill archive.
+    #[serde(default)]
+    pub sha256: Option<String>,
     /// Set to `true` when the registry flags this skill as suspicious.
     #[serde(default)]
     pub is_suspicious: bool,
+}
+
+/// Result returned after installing a skill archive.
+#[derive(Debug, Clone)]
+pub struct SkillInstallResult {
+    /// Path to the installed skill directory.
+    pub path: String,
+    /// Whether archive digest verification was performed successfully.
+    pub digest_verified: bool,
 }
 
 struct CacheEntry {
@@ -129,6 +142,18 @@ fn validate_slug(slug: &str) -> crate::error::Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Validate and normalize a SHA-256 digest string.
+fn normalize_sha256(digest: &str) -> crate::error::Result<String> {
+    let normalized = digest.trim().to_ascii_lowercase();
+    if normalized.len() != 64 || !normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(crate::error::ZeptoError::Tool(format!(
+            "Invalid SHA-256 digest '{}': expected 64 hex characters",
+            digest
+        )));
+    }
+    Ok(normalized)
 }
 
 /// Check whether `host` is in the allowed-hosts bypass list (case-insensitive).
@@ -330,9 +355,11 @@ impl ClawHubRegistry {
         &self,
         slug: &str,
         skills_dir: &str,
-    ) -> crate::error::Result<String> {
+        expected_sha256: Option<&str>,
+    ) -> crate::error::Result<SkillInstallResult> {
         // Validate slug before using it in a URL or filesystem path.
         validate_slug(slug)?;
+        let requested_sha256 = expected_sha256.map(normalize_sha256).transpose()?;
 
         let url = format!("{}/api/v1/download/{}", self.base_url, slug);
 
@@ -361,6 +388,17 @@ impl ClawHubRegistry {
             )));
         }
 
+        let response_sha256 = resp
+            .headers()
+            .get("x-skill-sha256")
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(normalize_sha256)
+            .transpose()?;
+
+        let verified_sha256 = requested_sha256.or(response_sha256);
+
         // Reject archives that are larger than 50 MB before buffering.
         if let Some(content_length) = resp.content_length() {
             if content_length > 50 * 1024 * 1024 {
@@ -376,6 +414,16 @@ impl ClawHubRegistry {
             .await
             .map_err(|e| crate::error::ZeptoError::Tool(e.to_string()))?;
 
+        if let Some(expected) = verified_sha256.as_deref() {
+            let actual = hex::encode(Sha256::digest(&bytes));
+            if actual != expected {
+                return Err(crate::error::ZeptoError::SecurityViolation(format!(
+                    "Skill archive SHA-256 mismatch: expected {}, got {}",
+                    expected, actual
+                )));
+            }
+        }
+
         let target_dir = format!("{}/{}", skills_dir, slug);
         tokio::fs::create_dir_all(&target_dir)
             .await
@@ -385,7 +433,7 @@ impl ClawHubRegistry {
         // holding non-Send ZipFile across await points.
         let bytes_vec = bytes.to_vec();
         let target_dir_clone = target_dir.clone();
-        tokio::task::spawn_blocking(move || {
+        let path = tokio::task::spawn_blocking(move || {
             let cursor = std::io::Cursor::new(bytes_vec);
             let mut archive = zip::ZipArchive::new(cursor)
                 .map_err(|e| crate::error::ZeptoError::Tool(e.to_string()))?;
@@ -422,7 +470,12 @@ impl ClawHubRegistry {
             Ok(target_dir_clone)
         })
         .await
-        .map_err(|e| crate::error::ZeptoError::Tool(e.to_string()))?
+        .map_err(|e| crate::error::ZeptoError::Tool(e.to_string()))??;
+
+        Ok(SkillInstallResult {
+            path,
+            digest_verified: verified_sha256.is_some(),
+        })
     }
 }
 
@@ -444,6 +497,7 @@ mod tests {
             display_name: "Test".into(),
             summary: "A test skill".into(),
             version: "1.0.0".into(),
+            sha256: None,
             is_suspicious: false,
         }];
         cache.set("test query:10", results.clone());
@@ -481,6 +535,7 @@ mod tests {
         let json = r#"{"slug":"x","display_name":"X","summary":"s","version":"1.0"}"#;
         let r: SkillSearchResult = serde_json::from_str(json).unwrap();
         assert!(!r.is_suspicious);
+        assert!(r.sha256.is_none());
     }
 
     #[test]
@@ -491,6 +546,7 @@ mod tests {
             display_name: "A".into(),
             summary: "".into(),
             version: "1.0".into(),
+            sha256: None,
             is_suspicious: false,
         }];
         let r2 = vec![SkillSearchResult {
@@ -498,6 +554,7 @@ mod tests {
             display_name: "B".into(),
             summary: "".into(),
             version: "2.0".into(),
+            sha256: None,
             is_suspicious: false,
         }];
         cache.set("query1:10", r1);
@@ -515,6 +572,7 @@ mod tests {
             display_name: "New".into(),
             summary: "updated".into(),
             version: "2.0".into(),
+            sha256: None,
             is_suspicious: false,
         }];
         cache.set("q:10", results);
@@ -593,6 +651,29 @@ mod tests {
         assert!(validate_slug("skill;rm -rf").is_err());
         assert!(validate_slug("skill<script>").is_err());
         assert!(validate_slug("skill%20encoded").is_err());
+    }
+
+    #[test]
+    fn test_normalize_sha256_accepts_valid_hex() {
+        let digest = "0123456789abcdef0123456789abcdef0123456789ABCDEF0123456789abcdef";
+        let normalized = normalize_sha256(digest).unwrap();
+        assert_eq!(
+            normalized,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn test_normalize_sha256_rejects_invalid_length() {
+        assert!(normalize_sha256("abcd").is_err());
+    }
+
+    #[test]
+    fn test_normalize_sha256_rejects_non_hex() {
+        assert!(normalize_sha256(
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+        )
+        .is_err());
     }
 
     // -------------------------------------------------------------------------

--- a/src/tools/skills_install.rs
+++ b/src/tools/skills_install.rs
@@ -72,11 +72,18 @@ impl Tool for InstallSkillTool {
             )));
         }
 
-        let sha256 = args
-            .get("sha256")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
+        let sha256 = match args.get("sha256") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(value)) => {
+                let digest = value.trim();
+                (!digest.is_empty()).then_some(digest)
+            }
+            Some(_) => {
+                return Ok(ToolOutput::error(
+                    "sha256 must be a string containing a 64-character hex digest",
+                ));
+            }
+        };
 
         match self
             .registry
@@ -213,5 +220,22 @@ mod tests {
             .unwrap();
         assert!(result.is_error);
         assert!(result.for_llm.contains("Invalid SHA-256 digest"));
+    }
+
+    #[tokio::test]
+    async fn test_install_non_string_sha256_returns_error() {
+        let tool = make_tool();
+        let ctx = ToolContext::new();
+        let result = tool
+            .execute(
+                serde_json::json!({"slug": "web-scraper", "sha256": 123}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result
+            .for_llm
+            .contains("sha256 must be a string containing a 64-character hex digest"));
     }
 }

--- a/src/tools/skills_install.rs
+++ b/src/tools/skills_install.rs
@@ -43,6 +43,10 @@ impl Tool for InstallSkillTool {
                 "slug": {
                     "type": "string",
                     "description": "Skill slug from find_skills results (e.g. 'web-scraper')"
+                },
+                "sha256": {
+                    "type": "string",
+                    "description": "Optional published SHA-256 digest for archive verification"
                 }
             },
             "required": ["slug"]
@@ -68,15 +72,28 @@ impl Tool for InstallSkillTool {
             )));
         }
 
+        let sha256 = args
+            .get("sha256")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
         match self
             .registry
-            .download_and_install(slug, &self.skills_dir)
+            .download_and_install(slug, &self.skills_dir, sha256)
             .await
         {
-            Ok(path) => Ok(ToolOutput::user_visible(format!(
-                "Skill '{}' installed to {}. Restart the agent to use it.",
-                slug, path
-            ))),
+            Ok(result) => {
+                let integrity_note = if result.digest_verified {
+                    "SHA-256 verified."
+                } else {
+                    "WARNING: archive digest not provided; integrity is unverified."
+                };
+                Ok(ToolOutput::user_visible(format!(
+                    "Skill '{}' installed to {}. {} Restart the agent to use it.",
+                    slug, result.path, integrity_note
+                )))
+            }
             Err(e) => Ok(ToolOutput::error(format!("Install failed: {}", e))),
         }
     }
@@ -109,6 +126,7 @@ mod tests {
     fn test_install_skill_tool_parameters() {
         let params = make_tool().parameters();
         assert!(params["properties"]["slug"].is_object());
+        assert!(params["properties"]["sha256"].is_object());
         let required = params["required"].as_array().unwrap();
         assert!(required.iter().any(|v| v.as_str() == Some("slug")));
     }
@@ -180,5 +198,20 @@ mod tests {
             .unwrap();
         assert!(result.is_error);
         assert!(result.for_llm.contains("Invalid skill slug"));
+    }
+
+    #[tokio::test]
+    async fn test_install_invalid_sha256_returns_error() {
+        let tool = make_tool();
+        let ctx = ToolContext::new();
+        let result = tool
+            .execute(
+                serde_json::json!({"slug": "web-scraper", "sha256": "not-a-valid-digest"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.for_llm.contains("Invalid SHA-256 digest"));
     }
 }

--- a/src/tools/skills_search.rs
+++ b/src/tools/skills_search.rs
@@ -69,9 +69,10 @@ impl Tool for FindSkillsTool {
                     } else {
                         ""
                     };
+                    let digest = r.sha256.as_deref().unwrap_or("(not published)");
                     out.push_str(&format!(
-                        "- **{}** (`{}`){}\n  Version: {}\n  {}\n\n",
-                        r.display_name, r.slug, warning, r.version, r.summary
+                        "- **{}** (`{}`){}\n  Version: {}\n  SHA-256: {}\n  {}\n\n",
+                        r.display_name, r.slug, warning, r.version, digest, r.summary
                     ));
                 }
                 Ok(ToolOutput::user_visible(out))


### PR DESCRIPTION
## Summary
- extend ClawHub skill metadata with optional sha256 digest
- allow install_skill to accept an optional sha256 and verify archive bytes before extraction
- auto-consume x-skill-sha256 response header when present
- surface digest status in install output and include digest visibility in find_skills output

## Notes
- plugin-side SHA-256 verification already exists for binary plugins; this PR adds digest verification support for skill downloads
- when no digest is provided/published, installation still works but is explicitly marked unverified

Closes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SHA-256 integrity verification for skill installations with optional manual digest input
  * Server-provided digests are reconciled with requested digests; mismatches block installation
  * Installation feedback now indicates whether digest verification succeeded
  * Skill search output shows published SHA-256 digests

* **Bug Fixes / Validation**
  * Rejects invalid non-hex or wrongly sized SHA-256 inputs with a clear error message
<!-- end of auto-generated comment: release notes by coderabbit.ai -->