### PR TITLE
feat(safety): add config-time SSRF endpoint validation

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -70,6 +70,20 @@ async fn cmd_config_check() -> Result<()> {
         .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Warn)
         .count();
 
+    // Provider endpoint SSRF validation.
+    let endpoint_diags = zeptoclaw::config::validate::validate_provider_api_bases(&config);
+    for diag in &endpoint_diags {
+        println!("{}", diag);
+    }
+    errors += endpoint_diags
+        .iter()
+        .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Error)
+        .count();
+    warnings += endpoint_diags
+        .iter()
+        .filter(|d| d.level == zeptoclaw::config::validate::DiagnosticLevel::Warn)
+        .count();
+
     // Hint: workspace configured but coding tools disabled
     let workspace = config.workspace_path();
     if workspace.exists() && !config.tools.coding_tools {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,6 +1,7 @@
 //! Config check and reset command handlers.
 
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 
 use zeptoclaw::config::Config;
 
@@ -71,7 +72,16 @@ async fn cmd_config_check() -> Result<()> {
         .count();
 
     // Provider endpoint SSRF validation.
-    let endpoint_diags = zeptoclaw::config::validate::validate_provider_api_bases(&config);
+    let seen_from_raw: HashSet<(String, String)> = diagnostics
+        .iter()
+        .map(|d| (d.path.clone(), d.message.clone()))
+        .collect();
+
+    let endpoint_diags: Vec<_> = zeptoclaw::config::validate::validate_provider_api_bases(&config)
+        .into_iter()
+        .filter(|d| !seen_from_raw.contains(&(d.path.clone(), d.message.clone())))
+        .collect();
+
     for diag in &endpoint_diags {
         println!("{}", diag);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,6 +53,9 @@ enum Commands {
         /// Run full 10-step wizard (express mode by default)
         #[arg(long)]
         full: bool,
+        /// Allow private/local provider endpoints during onboarding validation.
+        #[arg(long)]
+        allow_private_endpoints: bool,
     },
     /// Start interactive agent mode
     #[command(
@@ -625,8 +628,11 @@ pub async fn run() -> Result<()> {
         Some(Commands::Version) => {
             cmd_version();
         }
-        Some(Commands::Onboard { full }) => {
-            onboard::cmd_onboard(full).await?;
+        Some(Commands::Onboard {
+            full,
+            allow_private_endpoints,
+        }) => {
+            onboard::cmd_onboard(full, allow_private_endpoints).await?;
         }
         Some(Commands::Agent {
             message,

--- a/src/cli/onboard.rs
+++ b/src/cli/onboard.rs
@@ -14,7 +14,7 @@ use super::common::{memory_backend_label, memory_citations_label, read_line, rea
 /// Run the provider → API key → model selection flow.
 ///
 /// Pick provider first, then configure API key, then pick model.
-async fn configure_providers(config: &mut Config) -> Result<()> {
+async fn configure_providers(config: &mut Config, allow_private_endpoints: bool) -> Result<()> {
     let config_path = Config::path();
 
     println!("Provider Setup");
@@ -58,7 +58,7 @@ async fn configure_providers(config: &mut Config) -> Result<()> {
     println!();
     match primary {
         "anthropic" => configure_anthropic(config).await?,
-        "openai" => configure_openai(config).await?,
+        "openai" => configure_openai(config, allow_private_endpoints).await?,
         "openrouter" => configure_openrouter(config).await?,
         _ => {}
     }
@@ -99,7 +99,7 @@ async fn configure_providers(config: &mut Config) -> Result<()> {
                 println!();
                 match provider {
                     "anthropic" => configure_anthropic(config).await?,
-                    "openai" => configure_openai(config).await?,
+                    "openai" => configure_openai(config, allow_private_endpoints).await?,
                     "openrouter" => configure_openrouter(config).await?,
                     _ => {}
                 }
@@ -358,7 +358,7 @@ fn configure_soul(config: &Config) -> Result<()> {
 /// When `full` is false (default), runs express mode: creates directories
 /// silently, configures the LLM provider, saves, and prints guided next
 /// steps.  When `full` is true, runs the full 10-step interactive wizard.
-pub(crate) async fn cmd_onboard(full: bool) -> Result<()> {
+pub(crate) async fn cmd_onboard(full: bool, allow_private_endpoints: bool) -> Result<()> {
     // Check for existing OpenClaw installation
     if let Some(oc_dir) = zeptoclaw::migrate::detect_openclaw_dir() {
         println!("Detected OpenClaw installation at: {}", oc_dir.display());
@@ -388,6 +388,10 @@ pub(crate) async fn cmd_onboard(full: bool) -> Result<()> {
         Config::default()
     };
 
+    if allow_private_endpoints {
+        config.safety.allow_private_endpoints = true;
+    }
+
     if full {
         // ---------- full 10-step wizard ----------
         println!("Initializing ZeptoClaw (full wizard)...");
@@ -402,7 +406,7 @@ pub(crate) async fn cmd_onboard(full: bool) -> Result<()> {
         }
 
         println!();
-        configure_providers(&mut config).await?;
+        configure_providers(&mut config, allow_private_endpoints).await?;
         configure_soul(&config)?;
 
         // Configure web search integration
@@ -462,7 +466,7 @@ pub(crate) async fn cmd_onboard(full: bool) -> Result<()> {
             println!("  You can still add an API key later for official access.");
             println!();
         } else {
-            configure_providers(&mut config).await?;
+            configure_providers(&mut config, allow_private_endpoints).await?;
         }
 
         configure_soul(&config)?;
@@ -898,7 +902,7 @@ fn configure_anthropic_subscription_token(config: &mut Config) -> Result<()> {
 }
 
 /// Configure OpenAI provider.
-async fn configure_openai(config: &mut Config) -> Result<()> {
+async fn configure_openai(config: &mut Config, allow_private_endpoints: bool) -> Result<()> {
     println!();
     println!("OpenAI Setup");
     println!("------------");
@@ -954,8 +958,22 @@ async fn configure_openai(config: &mut Config) -> Result<()> {
 
         let base_url = read_line()?;
         if !base_url.is_empty() {
-            provider_config.api_base = Some(base_url);
-            println!("  Custom base URL configured.");
+            match zeptoclaw::config::validate::validate_network_endpoint(
+                &base_url,
+                allow_private_endpoints,
+            ) {
+                Ok(_) => {
+                    provider_config.api_base = Some(base_url);
+                    println!("  Custom base URL configured.");
+                }
+                Err(err) => {
+                    println!("  Invalid custom base URL: {}", err);
+                    println!("  Skipping custom base URL.");
+                    println!(
+                        "  Tip: use --allow-private-endpoints for trusted local development endpoints."
+                    );
+                }
+            }
         }
     } else {
         println!("  Skipped OpenAI configuration.");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2085,9 +2085,12 @@ mod tests {
 
     #[test]
     fn test_load_from_path_rejects_invalid_provider_endpoint() {
-        let env_key = "ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS";
-        let original = env::var(env_key).ok();
-        env::remove_var(env_key);
+        let allow_key = "ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS";
+        let base_key = "ZEPTOCLAW_PROVIDERS_OPENAI_API_BASE";
+        let original_allow = env::var(allow_key).ok();
+        let original_base = env::var(base_key).ok();
+        env::remove_var(allow_key);
+        env::remove_var(base_key);
 
         let temp_dir = tempfile::tempdir().unwrap();
         let config_path = temp_dir.path().join("config.json");
@@ -2106,10 +2109,16 @@ mod tests {
         let err = Config::load_from_path(&config_path).unwrap_err();
         assert!(err.to_string().contains("Invalid endpoint configuration"));
 
-        if let Some(value) = original {
-            env::set_var(env_key, value);
+        if let Some(value) = original_allow {
+            env::set_var(allow_key, value);
         } else {
-            env::remove_var(env_key);
+            env::remove_var(allow_key);
+        }
+
+        if let Some(value) = original_base {
+            env::set_var(base_key, value);
+        } else {
+            env::remove_var(base_key);
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,7 @@ use once_cell::sync::OnceCell;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::RwLock;
-use tracing::warn;
+use tracing::{error, warn};
 
 /// Global configuration instance
 static CONFIG: OnceCell<RwLock<Config>> = OnceCell::new();
@@ -68,12 +68,28 @@ impl Config {
         // Apply environment variable overrides
         config.apply_env_overrides();
 
-        for diag in crate::config::validate::validate_provider_api_bases(&config) {
+        let endpoint_diags = crate::config::validate::validate_provider_api_bases(&config);
+        for diag in &endpoint_diags {
             warn!(
                 path = %diag.path,
                 message = %diag.message,
                 "Config endpoint validation warning"
             );
+        }
+
+        if let Some(diag) = endpoint_diags
+            .iter()
+            .find(|d| d.level == crate::config::validate::DiagnosticLevel::Error)
+        {
+            error!(
+                path = %diag.path,
+                message = %diag.message,
+                "Config endpoint validation failed"
+            );
+            return Err(ZeptoError::Config(format!(
+                "Invalid endpoint configuration at {}: {}",
+                diag.path, diag.message
+            )));
         }
 
         Ok(config)
@@ -2065,6 +2081,36 @@ mod tests {
 
         // Clean up
         fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_load_from_path_rejects_invalid_provider_endpoint() {
+        let env_key = "ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS";
+        let original = env::var(env_key).ok();
+        env::remove_var(env_key);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{
+                "providers": {
+                    "openai": {
+                        "api_base": "http://127.0.0.1:11434/v1"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = Config::load_from_path(&config_path).unwrap_err();
+        assert!(err.to_string().contains("Invalid endpoint configuration"));
+
+        if let Some(value) = original {
+            env::set_var(env_key, value);
+        } else {
+            env::remove_var(env_key);
+        }
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ use once_cell::sync::OnceCell;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use tracing::warn;
 
 /// Global configuration instance
 static CONFIG: OnceCell<RwLock<Config>> = OnceCell::new();
@@ -66,6 +67,14 @@ impl Config {
 
         // Apply environment variable overrides
         config.apply_env_overrides();
+
+        for diag in crate::config::validate::validate_provider_api_bases(&config) {
+            warn!(
+                path = %diag.path,
+                message = %diag.message,
+                "Config endpoint validation warning"
+            );
+        }
 
         Ok(config)
     }
@@ -1303,6 +1312,9 @@ impl Config {
             if let Ok(v) = val.parse::<usize>() {
                 self.safety.max_output_length = v.clamp(1_000, 10_000_000);
             }
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS") {
+            self.safety.allow_private_endpoints = val.eq_ignore_ascii_case("true") || val == "1";
         }
         if let Ok(val) = std::env::var("ZEPTOCLAW_SAFETY_TAINT_ENABLED") {
             self.safety.taint.enabled = val.eq_ignore_ascii_case("true") || val == "1";

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,7 +36,7 @@ fn sanitize_endpoint_for_logging(endpoint: &str) -> String {
 
 fn sanitize_endpoint_diagnostic_message(message: &str) -> String {
     if let Some(rest) = message.strip_prefix("Invalid URL '") {
-        if let Some((endpoint, tail)) = rest.split_once("': ") {
+        if let Some((endpoint, tail)) = rest.rsplit_once("': ") {
             return format!(
                 "Invalid URL '{}': {}",
                 sanitize_endpoint_for_logging(endpoint),
@@ -1775,6 +1775,14 @@ mod tests {
         let sanitized = sanitize_endpoint_diagnostic_message(message);
         assert!(sanitized.contains("[redacted endpoint]"));
         assert!(!sanitized.contains("secret"));
+        assert!(!sanitized.contains("token=abcd"));
+    }
+
+    #[test]
+    fn test_sanitize_endpoint_diagnostic_message_handles_embedded_delimiter() {
+        let message = "Invalid URL 'http://[::1': token=abcd': invalid IPv6 address";
+        let sanitized = sanitize_endpoint_diagnostic_message(message);
+        assert!(sanitized.contains("[redacted endpoint]"));
         assert!(!sanitized.contains("token=abcd"));
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,9 +16,36 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::RwLock;
 use tracing::{error, warn};
+use url::Url;
 
 /// Global configuration instance
 static CONFIG: OnceCell<RwLock<Config>> = OnceCell::new();
+
+fn sanitize_endpoint_for_logging(endpoint: &str) -> String {
+    Url::parse(endpoint)
+        .ok()
+        .map(|mut parsed| {
+            let _ = parsed.set_password(None);
+            let _ = parsed.set_username("");
+            parsed.set_query(None);
+            parsed.set_fragment(None);
+            parsed.to_string()
+        })
+        .unwrap_or_else(|| "[redacted endpoint]".to_string())
+}
+
+fn sanitize_endpoint_diagnostic_message(message: &str) -> String {
+    if let Some(rest) = message.strip_prefix("Invalid URL '") {
+        if let Some((endpoint, tail)) = rest.split_once("': ") {
+            return format!(
+                "Invalid URL '{}': {}",
+                sanitize_endpoint_for_logging(endpoint),
+                tail
+            );
+        }
+    }
+    message.to_string()
+}
 
 impl Config {
     /// Returns the ZeptoClaw configuration directory path (~/.zeptoclaw)
@@ -70,9 +97,10 @@ impl Config {
 
         let endpoint_diags = crate::config::validate::validate_provider_api_bases(&config);
         for diag in &endpoint_diags {
+            let sanitized_message = sanitize_endpoint_diagnostic_message(&diag.message);
             warn!(
                 path = %diag.path,
-                message = %diag.message,
+                message = %sanitized_message,
                 "Config endpoint validation warning"
             );
         }
@@ -81,14 +109,15 @@ impl Config {
             .iter()
             .find(|d| d.level == crate::config::validate::DiagnosticLevel::Error)
         {
+            let sanitized_message = sanitize_endpoint_diagnostic_message(&diag.message);
             error!(
                 path = %diag.path,
-                message = %diag.message,
+                message = %sanitized_message,
                 "Config endpoint validation failed"
             );
             return Err(ZeptoError::Config(format!(
                 "Invalid endpoint configuration at {}: {}",
-                diag.path, diag.message
+                diag.path, sanitized_message
             )));
         }
 
@@ -1726,6 +1755,27 @@ mod tests {
         // Defaults should apply to unspecified fields
         assert_eq!(config.agents.defaults.temperature, 0.7);
         assert_eq!(config.gateway.port, 8080);
+    }
+
+    #[test]
+    fn test_sanitize_endpoint_diagnostic_message_redacts_credentials() {
+        let message =
+            "Invalid URL 'https://user:secret@example.com/v1?api_key=abcd#frag': parse failure";
+        let sanitized = sanitize_endpoint_diagnostic_message(message);
+        assert!(sanitized.contains("https://example.com/v1"));
+        assert!(!sanitized.contains("user"));
+        assert!(!sanitized.contains("secret"));
+        assert!(!sanitized.contains("api_key=abcd"));
+        assert!(!sanitized.contains("#frag"));
+    }
+
+    #[test]
+    fn test_sanitize_endpoint_diagnostic_message_handles_unparseable_url() {
+        let message = "Invalid URL 'https://user:secret@exa mple.com/?token=abcd': bad host";
+        let sanitized = sanitize_endpoint_diagnostic_message(message);
+        assert!(sanitized.contains("[redacted endpoint]"));
+        assert!(!sanitized.contains("secret"));
+        assert!(!sanitized.contains("token=abcd"));
     }
 
     #[test]

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -274,12 +274,16 @@ pub fn validate_config(raw: &Value) -> Vec<Diagnostic> {
     }
 
     // Security warnings
-    let allow_private_endpoints = obj
-        .get("safety")
-        .and_then(|v| v.as_object())
-        .and_then(|s| s.get("allow_private_endpoints"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let allow_private_endpoints = std::env::var("ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS")
+        .ok()
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or_else(|| {
+            obj.get("safety")
+                .and_then(|v| v.as_object())
+                .and_then(|s| s.get("allow_private_endpoints"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        });
 
     if let Some(providers) = obj.get("providers").and_then(|v| v.as_object()) {
         for (provider_name, provider_val) in providers {
@@ -972,6 +976,34 @@ mod tests {
         assert!(!diags
             .iter()
             .any(|d| d.path == "providers.openai.api_base" && d.level == DiagnosticLevel::Error));
+    }
+
+    #[test]
+    fn test_validate_provider_api_base_honors_env_override() {
+        let env_key = "ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS";
+        let original = std::env::var(env_key).ok();
+        std::env::set_var(env_key, "1");
+
+        let raw = json!({
+            "safety": {
+                "allow_private_endpoints": false
+            },
+            "providers": {
+                "openai": {
+                    "api_base": "http://127.0.0.1:11434/v1"
+                }
+            }
+        });
+        let diags = validate_config(&raw);
+        assert!(!diags
+            .iter()
+            .any(|d| d.path == "providers.openai.api_base" && d.level == DiagnosticLevel::Error));
+
+        if let Some(value) = original {
+            std::env::set_var(env_key, value);
+        } else {
+            std::env::remove_var(env_key);
+        }
     }
 
     #[test]

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -3,6 +3,10 @@
 use serde_json::Value;
 use std::collections::HashSet;
 
+use reqwest::Url;
+
+use crate::tools::web::is_blocked_host;
+
 /// Known top-level config field names.
 const KNOWN_TOP_LEVEL: &[&str] = &[
     "agents",
@@ -145,6 +149,35 @@ pub fn suggest_field(unknown: &str, known: &[&str]) -> Option<String> {
         .map(|(k, _)| format!("did you mean '{}'?", k))
 }
 
+/// Validate an external HTTP(S) endpoint for SSRF-safe config usage.
+///
+/// Uses the same blocked-host logic as `web_fetch` for local/private endpoints.
+pub fn validate_network_endpoint(
+    endpoint: &str,
+    allow_private_endpoints: bool,
+) -> std::result::Result<(), String> {
+    let parsed = Url::parse(endpoint).map_err(|e| format!("Invalid URL '{}': {}", endpoint, e))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "Unsupported URL scheme '{}' (expected http/https)",
+                other
+            ));
+        }
+    }
+
+    if !allow_private_endpoints && is_blocked_host(&parsed) {
+        return Err(
+            "Endpoint targets local/private network. Set safety.allow_private_endpoints=true (or ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS=1) only for trusted local development."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 /// Validate a raw JSON config value against known field names.
 pub fn validate_config(raw: &Value) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
@@ -241,6 +274,36 @@ pub fn validate_config(raw: &Value) -> Vec<Diagnostic> {
     }
 
     // Security warnings
+    let allow_private_endpoints = obj
+        .get("safety")
+        .and_then(|v| v.as_object())
+        .and_then(|s| s.get("allow_private_endpoints"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if let Some(providers) = obj.get("providers").and_then(|v| v.as_object()) {
+        for (provider_name, provider_val) in providers {
+            // Vertex uses api_base as region/location, not a URL endpoint.
+            if provider_name == "vertex" {
+                continue;
+            }
+
+            if let Some(api_base) = provider_val
+                .as_object()
+                .and_then(|p| p.get("api_base"))
+                .and_then(|v| v.as_str())
+            {
+                if let Err(message) = validate_network_endpoint(api_base, allow_private_endpoints) {
+                    diagnostics.push(Diagnostic {
+                        level: DiagnosticLevel::Error,
+                        path: format!("providers.{}.api_base", provider_name),
+                        message,
+                    });
+                }
+            }
+        }
+    }
+
     if let Some(channels) = obj.get("channels").and_then(|v| v.as_object()) {
         for (name, channel_val) in channels {
             if let Some(channel_obj) = channel_val.as_object() {
@@ -329,6 +392,41 @@ pub fn validate_config(raw: &Value) -> Vec<Diagnostic> {
                         level: DiagnosticLevel::Warn,
                         path: "r8r_bridge.endpoint".to_string(),
                         message: "Plaintext ws:// on non-loopback address \u{2014} bearer token will be sent in cleartext; use wss://".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+/// Validate configured provider API base endpoints from a typed config.
+pub fn validate_provider_api_bases(config: &crate::config::Config) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let allow_private_endpoints = config.safety.allow_private_endpoints;
+    let providers_value = match serde_json::to_value(&config.providers) {
+        Ok(v) => v,
+        Err(_) => return diagnostics,
+    };
+
+    if let Some(providers) = providers_value.as_object() {
+        for (provider_name, provider_val) in providers {
+            // Vertex uses api_base as region/location, not a URL endpoint.
+            if provider_name == "vertex" {
+                continue;
+            }
+
+            if let Some(api_base) = provider_val
+                .as_object()
+                .and_then(|p| p.get("api_base"))
+                .and_then(|v| v.as_str())
+            {
+                if let Err(message) = validate_network_endpoint(api_base, allow_private_endpoints) {
+                    diagnostics.push(Diagnostic {
+                        level: DiagnosticLevel::Error,
+                        path: format!("providers.{}.api_base", provider_name),
+                        message,
                     });
                 }
             }
@@ -841,6 +939,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_validate_provider_api_base_blocks_private_by_default() {
+        let raw = json!({
+            "providers": {
+                "openai": {
+                    "api_base": "http://127.0.0.1:11434/v1"
+                }
+            }
+        });
+        let diags = validate_config(&raw);
+        assert!(diags.iter().any(|d| {
+            d.level == DiagnosticLevel::Error
+                && d.path == "providers.openai.api_base"
+                && d.message.contains("private")
+        }));
+    }
+
+    #[test]
+    fn test_validate_provider_api_base_allows_private_when_configured() {
+        let raw = json!({
+            "safety": {
+                "allow_private_endpoints": true
+            },
+            "providers": {
+                "openai": {
+                    "api_base": "http://127.0.0.1:11434/v1"
+                }
+            }
+        });
+        let diags = validate_config(&raw);
+        assert!(!diags
+            .iter()
+            .any(|d| d.path == "providers.openai.api_base" && d.level == DiagnosticLevel::Error));
+    }
+
+    #[test]
+    fn test_validate_provider_api_base_rejects_unsupported_scheme() {
+        let raw = json!({
+            "providers": {
+                "openai": {
+                    "api_base": "file:///etc/passwd"
+                }
+            }
+        });
+        let diags = validate_config(&raw);
+        assert!(diags.iter().any(|d| {
+            d.level == DiagnosticLevel::Error
+                && d.path == "providers.openai.api_base"
+                && d.message.contains("Unsupported URL scheme")
+        }));
+    }
+
     // --- Model-provider compatibility unit tests ---
 
     #[test]
@@ -949,5 +1099,30 @@ mod tests {
         });
         let diags = validate_config(&raw);
         assert!(!diags.iter().any(|d| d.path == "r8r_bridge.endpoint"));
+    }
+
+    #[test]
+    fn test_validate_provider_api_bases_typed_config_blocks_private() {
+        let mut config = Config::default();
+        config.providers.openai = Some(crate::config::ProviderConfig {
+            api_base: Some("http://127.0.0.1:11434/v1".to_string()),
+            ..Default::default()
+        });
+        let diags = validate_provider_api_bases(&config);
+        assert!(diags
+            .iter()
+            .any(|d| d.path == "providers.openai.api_base" && d.level == DiagnosticLevel::Error));
+    }
+
+    #[test]
+    fn test_validate_provider_api_bases_typed_config_allows_private_with_override() {
+        let mut config = Config::default();
+        config.safety.allow_private_endpoints = true;
+        config.providers.openai = Some(crate::config::ProviderConfig {
+            api_base: Some("http://127.0.0.1:11434/v1".to_string()),
+            ..Default::default()
+        });
+        let diags = validate_provider_api_bases(&config);
+        assert!(diags.is_empty());
     }
 }

--- a/src/safety/mod.rs
+++ b/src/safety/mod.rs
@@ -35,6 +35,11 @@ pub struct SafetyConfig {
     pub leak_detection_enabled: bool,
     /// Maximum tool output length in bytes before truncation.
     pub max_output_length: usize,
+    /// Allow private/local endpoints in provider `api_base` validation checks.
+    ///
+    /// Keep this disabled in production. Enable only for trusted local
+    /// development endpoints such as Ollama/vLLM on LAN/loopback.
+    pub allow_private_endpoints: bool,
     /// Taint tracking configuration.
     pub taint: taint::TaintConfig,
 }
@@ -46,6 +51,7 @@ impl Default for SafetyConfig {
             injection_check_enabled: true,
             leak_detection_enabled: true,
             max_output_length: 100_000,
+            allow_private_endpoints: false,
             taint: taint::TaintConfig::default(),
         }
     }
@@ -323,6 +329,7 @@ mod tests {
         assert!(config.injection_check_enabled);
         assert!(config.leak_detection_enabled);
         assert_eq!(config.max_output_length, 100_000);
+        assert!(!config.allow_private_endpoints);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared endpoint validation for provider api_base values (http/https only + blocked-host checks)
- surface endpoint diagnostics in zeptoclaw config check and typed config validation
- add onboarding flag --allow-private-endpoints and validate custom OpenAI base URLs during onboarding
- add safety.allow_private_endpoints config/env override and startup warnings for unsafe endpoint configs

## Behavior
- private/local endpoints are blocked by default in validation paths
- trusted local development endpoints can be explicitly allowed with:
  - config: safety.allow_private_endpoints=true
  - env: ZEPTOCLAW_SAFETY_ALLOW_PRIVATE_ENDPOINTS=1
  - onboard: --allow-private-endpoints

Closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag to allow private endpoints during onboarding and an env var to toggle this behavior; provider endpoints must use HTTP(S).

* **Bug Fixes**
  * Improved configuration validation: endpoint diagnostics are sanitized, deduplicated, and aggregated so new errors/warnings affect final results; invalid endpoints can now cause config load to fail.
  * Validation behavior unified between raw and typed config paths.

* **Tests**
  * Added unit tests for endpoint validation and allowlist/denylist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->