### PR TITLE
feat: add in-memory hash-chain audit trail for tool execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Project-level guidance for coding agents working in this repository.
 - Safer default execution posture: fresh configs now start in `agent_mode = "assistant"` with approvals enabled under the `require_for_dangerous` policy
 - Gateway startup guard: degrade after N crashes to prevent crash loops
 - Loop guard: SHA256 tool-call repetition detection with warn + circuit-breaker stop
+- In-memory audit hash-chain: `src/audit.rs` appends SHA-256-linked entries (`record_audit_chain_event`, `verify_audit_chain_integrity`, `recent_audit_entries`, `audit_tip_hash`), and `kernel::execute_tool()` now emits tool execution chain events with shell/network/spawn classification
 - Tool execution hardening: per-tool-call timeout + panic capture in both `process_message` and `process_message_streaming` tool `join_all` paths
 - Streaming tool parity: `process_message_streaming()` now mirrors non-streaming hook callbacks, usage-metric accounting, success/failure logging, thinking/response feedback, and malformed tool-argument parse preservation
 - Context trimming: normal/emergency/critical compaction tiers (70%/90%/95%)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ For detailed module docs see `docs/claude/architecture.md`.
 - Model-driven provider inference treats vendor-prefixed gateway IDs like `anthropic/...` as OpenRouter models only when OpenRouter is actually available, and live provider model discovery now carries `api-version` while normalizing Azure deployment bases to `/openai/models`.
 - The OpenAI-compatible `/v1/chat/completions` serve path forwards request tools, returns OpenAI-style tool-call payloads for assistant/tool messages, and the default provider streaming adapter now emits a text delta plus tool-call events before `Done` so non-native streaming providers are not silently flattened.
 - The serve API only accepts omitted, `null`, or `"auto"` for `tool_choice`; unsupported values are rejected with `400` instead of being ignored.
+- `src/audit.rs` now includes an in-memory SHA-256 hash chain (`record_audit_chain_event`, `verify_audit_chain_integrity`, `recent_audit_entries`, `audit_tip_hash`), and `kernel::execute_tool()` records per-call audit entries including shell/network/spawn classifications.
 - `shell` tool output is truncated at 2,000 lines / 50KB before it reaches the model context.
 - `grep` reports subprocess failures instead of collapsing them into "No matches found".
 - `edit_file` rejects empty `old_text` and accepts optional `expected_replacements` to guard exact-match edits.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -7,6 +7,7 @@
 use chrono::Utc;
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
+use std::collections::VecDeque;
 use std::sync::Mutex;
 use tracing::{error, info, warn};
 
@@ -113,23 +114,30 @@ pub struct AuditEntry {
     pub hash: String,
 }
 
+const MAX_AUDIT_ENTRIES: usize = 10_000;
+
 #[derive(Debug)]
 struct AuditHashChain {
     state: Mutex<AuditChainState>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct AuditChainState {
-    entries: Vec<AuditEntry>,
+    entries: VecDeque<AuditEntry>,
     tip: String,
+    window_base_hash: String,
+    next_seq: u64,
 }
 
 impl Default for AuditHashChain {
     fn default() -> Self {
+        let genesis = genesis_hash();
         Self {
             state: Mutex::new(AuditChainState {
-                entries: Vec::new(),
-                tip: genesis_hash(),
+                entries: VecDeque::new(),
+                tip: genesis.clone(),
+                window_base_hash: genesis,
+                next_seq: 1,
             }),
         }
     }
@@ -144,7 +152,7 @@ impl AuditHashChain {
         outcome: &str,
     ) -> AuditEntry {
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        let seq = state.entries.len() as u64 + 1;
+        let seq = state.next_seq;
         let timestamp = Utc::now().to_rfc3339();
         let agent_id = sanitize_text(agent_id, 120);
         let detail = sanitize_text(detail, 512);
@@ -166,15 +174,32 @@ impl AuditHashChain {
         };
 
         state.tip = hash;
-        state.entries.push(entry.clone());
+        state.next_seq = state.next_seq.saturating_add(1);
+        state.entries.push_back(entry.clone());
+        if state.entries.len() > MAX_AUDIT_ENTRIES {
+            if let Some(evicted) = state.entries.pop_front() {
+                state.window_base_hash = evicted.hash;
+            }
+        }
         entry
     }
 
     fn verify_integrity(&self) -> std::result::Result<(), String> {
         let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        let mut expected_prev = genesis_hash();
+        let mut expected_prev = state.window_base_hash.clone();
+        let mut expected_seq = state
+            .entries
+            .front()
+            .map(|e| e.seq)
+            .unwrap_or(state.next_seq);
 
         for entry in &state.entries {
+            if entry.seq != expected_seq {
+                return Err(format!(
+                    "chain broken at seq {}: sequence mismatch",
+                    entry.seq
+                ));
+            }
             if entry.prev_hash != expected_prev {
                 return Err(format!(
                     "chain broken at seq {}: prev hash mismatch",
@@ -197,10 +222,14 @@ impl AuditHashChain {
             }
 
             expected_prev = entry.hash.clone();
+            expected_seq = expected_seq.saturating_add(1);
         }
 
         if state.tip != expected_prev {
             return Err("chain broken: tip does not match final entry hash".to_string());
+        }
+        if state.next_seq != expected_seq {
+            return Err("chain broken: next sequence mismatch".to_string());
         }
 
         Ok(())
@@ -212,7 +241,7 @@ impl AuditHashChain {
             return Vec::new();
         }
         let start = state.entries.len().saturating_sub(n);
-        state.entries[start..].to_vec()
+        state.entries.iter().skip(start).cloned().collect()
     }
 
     fn tip_hash(&self) -> String {
@@ -235,12 +264,20 @@ fn compute_entry_hash(
     outcome: &str,
     prev_hash: &str,
 ) -> String {
-    let payload = format!(
-        "{}|{}|{}|{}|{}|{}|{}",
-        seq, timestamp, agent_id, action, detail, outcome, prev_hash
-    );
-    let digest = Sha256::digest(payload.as_bytes());
-    hex::encode(digest)
+    let mut hasher = Sha256::new();
+    hasher.update(seq.to_le_bytes());
+    hash_string_field(&mut hasher, timestamp);
+    hash_string_field(&mut hasher, agent_id);
+    hash_string_field(&mut hasher, &action.to_string());
+    hash_string_field(&mut hasher, detail);
+    hash_string_field(&mut hasher, outcome);
+    hash_string_field(&mut hasher, prev_hash);
+    hex::encode(hasher.finalize())
+}
+
+fn hash_string_field(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
 }
 
 fn genesis_hash() -> String {
@@ -411,11 +448,54 @@ mod tests {
 
         {
             let mut state = chain.state.lock().unwrap_or_else(|e| e.into_inner());
-            state.entries[1].detail = "tampered".to_string();
+            state.entries.get_mut(1).unwrap().detail = "tampered".to_string();
         }
 
         let err = chain.verify_integrity().unwrap_err();
         assert!(err.contains("hash mismatch"));
+    }
+
+    #[test]
+    fn test_hash_chain_is_bounded() {
+        let chain = AuditHashChain::default();
+        for idx in 0..(MAX_AUDIT_ENTRIES + 3) {
+            chain.record(
+                "agent-b",
+                AuditAction::ToolInvoke,
+                &format!("tool={idx}"),
+                "ok",
+            );
+        }
+
+        let recent = chain.recent(MAX_AUDIT_ENTRIES + 50);
+        assert_eq!(recent.len(), MAX_AUDIT_ENTRIES);
+        assert_eq!(recent.first().unwrap().seq, 4);
+        assert_eq!(recent.last().unwrap().seq, (MAX_AUDIT_ENTRIES + 3) as u64);
+        assert_eq!(chain.verify_integrity(), Ok(()));
+    }
+
+    #[test]
+    fn test_hash_payload_is_unambiguous() {
+        let prev = genesis_hash();
+        let hash_a = compute_entry_hash(
+            1,
+            "2026-04-22T00:00:00Z",
+            "agent",
+            AuditAction::ToolInvoke,
+            "a|b",
+            "c",
+            &prev,
+        );
+        let hash_b = compute_entry_hash(
+            1,
+            "2026-04-22T00:00:00Z",
+            "agent",
+            AuditAction::ToolInvoke,
+            "a",
+            "b|c",
+            &prev,
+        );
+        assert_ne!(hash_a, hash_b);
     }
 
     #[test]

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -4,6 +4,10 @@
 //! downstream log aggregators (Loki, Datadog, etc.) can filter on
 //! `audit=true` and query by `category`, `event_type`, `severity`, etc.
 
+use chrono::Utc;
+use once_cell::sync::Lazy;
+use sha2::{Digest, Sha256};
+use std::sync::Mutex;
 use tracing::{error, info, warn};
 
 /// Broad category of audit event.
@@ -64,6 +68,210 @@ impl std::fmt::Display for AuditSeverity {
             Self::Critical => write!(f, "critical"),
         }
     }
+}
+
+/// Action type in the execution hash chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditAction {
+    ToolInvoke,
+    ShellExec,
+    NetworkAccess,
+    AgentSpawn,
+    AgentMessage,
+    MemoryAccess,
+    FileAccess,
+    AuthAttempt,
+    ConfigChange,
+}
+
+impl std::fmt::Display for AuditAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ToolInvoke => write!(f, "tool_invoke"),
+            Self::ShellExec => write!(f, "shell_exec"),
+            Self::NetworkAccess => write!(f, "network_access"),
+            Self::AgentSpawn => write!(f, "agent_spawn"),
+            Self::AgentMessage => write!(f, "agent_message"),
+            Self::MemoryAccess => write!(f, "memory_access"),
+            Self::FileAccess => write!(f, "file_access"),
+            Self::AuthAttempt => write!(f, "auth_attempt"),
+            Self::ConfigChange => write!(f, "config_change"),
+        }
+    }
+}
+
+/// One immutable chain entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditEntry {
+    pub seq: u64,
+    pub timestamp: String,
+    pub agent_id: String,
+    pub action: AuditAction,
+    pub detail: String,
+    pub outcome: String,
+    pub prev_hash: String,
+    pub hash: String,
+}
+
+#[derive(Debug)]
+struct AuditHashChain {
+    state: Mutex<AuditChainState>,
+}
+
+#[derive(Debug, Default)]
+struct AuditChainState {
+    entries: Vec<AuditEntry>,
+    tip: String,
+}
+
+impl Default for AuditHashChain {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(AuditChainState {
+                entries: Vec::new(),
+                tip: genesis_hash(),
+            }),
+        }
+    }
+}
+
+impl AuditHashChain {
+    fn record(
+        &self,
+        agent_id: &str,
+        action: AuditAction,
+        detail: &str,
+        outcome: &str,
+    ) -> AuditEntry {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let seq = state.entries.len() as u64 + 1;
+        let timestamp = Utc::now().to_rfc3339();
+        let agent_id = sanitize_text(agent_id, 120);
+        let detail = sanitize_text(detail, 512);
+        let outcome = sanitize_text(outcome, 120);
+        let prev_hash = state.tip.clone();
+        let hash = compute_entry_hash(
+            seq, &timestamp, &agent_id, action, &detail, &outcome, &prev_hash,
+        );
+
+        let entry = AuditEntry {
+            seq,
+            timestamp,
+            agent_id,
+            action,
+            detail,
+            outcome,
+            prev_hash,
+            hash: hash.clone(),
+        };
+
+        state.tip = hash;
+        state.entries.push(entry.clone());
+        entry
+    }
+
+    fn verify_integrity(&self) -> std::result::Result<(), String> {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut expected_prev = genesis_hash();
+
+        for entry in &state.entries {
+            if entry.prev_hash != expected_prev {
+                return Err(format!(
+                    "chain broken at seq {}: prev hash mismatch",
+                    entry.seq
+                ));
+            }
+
+            let expected_hash = compute_entry_hash(
+                entry.seq,
+                &entry.timestamp,
+                &entry.agent_id,
+                entry.action,
+                &entry.detail,
+                &entry.outcome,
+                &expected_prev,
+            );
+
+            if entry.hash != expected_hash {
+                return Err(format!("chain broken at seq {}: hash mismatch", entry.seq));
+            }
+
+            expected_prev = entry.hash.clone();
+        }
+
+        if state.tip != expected_prev {
+            return Err("chain broken: tip does not match final entry hash".to_string());
+        }
+
+        Ok(())
+    }
+
+    fn recent(&self, n: usize) -> Vec<AuditEntry> {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if n == 0 || state.entries.is_empty() {
+            return Vec::new();
+        }
+        let start = state.entries.len().saturating_sub(n);
+        state.entries[start..].to_vec()
+    }
+
+    fn tip_hash(&self) -> String {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.tip.clone()
+    }
+}
+
+fn sanitize_text(value: &str, max_len: usize) -> String {
+    let normalized = value.trim().replace(['\n', '\r'], " ");
+    normalized.chars().take(max_len).collect()
+}
+
+fn compute_entry_hash(
+    seq: u64,
+    timestamp: &str,
+    agent_id: &str,
+    action: AuditAction,
+    detail: &str,
+    outcome: &str,
+    prev_hash: &str,
+) -> String {
+    let payload = format!(
+        "{}|{}|{}|{}|{}|{}|{}",
+        seq, timestamp, agent_id, action, detail, outcome, prev_hash
+    );
+    let digest = Sha256::digest(payload.as_bytes());
+    hex::encode(digest)
+}
+
+fn genesis_hash() -> String {
+    "0".repeat(64)
+}
+
+static AUDIT_CHAIN: Lazy<AuditHashChain> = Lazy::new(AuditHashChain::default);
+
+/// Append a new event to the in-memory audit hash chain.
+pub fn record_audit_chain_event(
+    agent_id: &str,
+    action: AuditAction,
+    detail: &str,
+    outcome: &str,
+) -> AuditEntry {
+    AUDIT_CHAIN.record(agent_id, action, detail, outcome)
+}
+
+/// Verify integrity of all in-memory audit chain entries.
+pub fn verify_audit_chain_integrity() -> std::result::Result<(), String> {
+    AUDIT_CHAIN.verify_integrity()
+}
+
+/// Return the `n` most recent chain entries.
+pub fn recent_audit_entries(n: usize) -> Vec<AuditEntry> {
+    AUDIT_CHAIN.recent(n)
+}
+
+/// Return current chain tip hash.
+pub fn audit_tip_hash() -> String {
+    AUDIT_CHAIN.tip_hash()
 }
 
 /// Emit a structured audit event via `tracing`.
@@ -150,6 +358,67 @@ mod tests {
     }
 
     #[test]
+    fn test_audit_action_display() {
+        assert_eq!(AuditAction::ToolInvoke.to_string(), "tool_invoke");
+        assert_eq!(AuditAction::ShellExec.to_string(), "shell_exec");
+        assert_eq!(AuditAction::NetworkAccess.to_string(), "network_access");
+        assert_eq!(AuditAction::AgentSpawn.to_string(), "agent_spawn");
+        assert_eq!(AuditAction::AgentMessage.to_string(), "agent_message");
+        assert_eq!(AuditAction::MemoryAccess.to_string(), "memory_access");
+        assert_eq!(AuditAction::FileAccess.to_string(), "file_access");
+        assert_eq!(AuditAction::AuthAttempt.to_string(), "auth_attempt");
+        assert_eq!(AuditAction::ConfigChange.to_string(), "config_change");
+    }
+
+    #[test]
+    fn test_hash_chain_record_and_verify() {
+        let chain = AuditHashChain::default();
+
+        let first = chain.record("agent-a", AuditAction::ToolInvoke, "tool=echo", "success");
+        let second = chain.record("agent-a", AuditAction::ShellExec, "tool=shell", "success");
+
+        assert_eq!(first.seq, 1);
+        assert_eq!(second.seq, 2);
+        assert_eq!(second.prev_hash, first.hash);
+        assert_eq!(chain.verify_integrity(), Ok(()));
+    }
+
+    #[test]
+    fn test_hash_chain_recent_and_tip() {
+        let chain = AuditHashChain::default();
+        assert_eq!(chain.tip_hash(), genesis_hash());
+
+        let first = chain.record("agent-x", AuditAction::ToolInvoke, "tool=echo", "ok");
+        let second = chain.record(
+            "agent-x",
+            AuditAction::NetworkAccess,
+            "tool=web_fetch",
+            "ok",
+        );
+        assert_ne!(first.hash, chain.tip_hash());
+        assert_eq!(second.hash, chain.tip_hash());
+
+        let recent = chain.recent(1);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].seq, 2);
+    }
+
+    #[test]
+    fn test_hash_chain_detects_tampering() {
+        let chain = AuditHashChain::default();
+        chain.record("agent-t", AuditAction::ToolInvoke, "tool=echo", "success");
+        chain.record("agent-t", AuditAction::ToolInvoke, "tool=shell", "success");
+
+        {
+            let mut state = chain.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.entries[1].detail = "tampered".to_string();
+        }
+
+        let err = chain.verify_integrity().unwrap_err();
+        assert!(err.contains("hash mismatch"));
+    }
+
+    #[test]
     fn test_log_audit_event_info() {
         // Should not panic — emits a tracing event at info level.
         log_audit_event(
@@ -190,11 +459,15 @@ mod tests {
         assert_ne!(AuditCategory::ShellSecurity, AuditCategory::PathSecurity);
         assert_eq!(AuditSeverity::Critical, AuditSeverity::Critical);
         assert_ne!(AuditSeverity::Info, AuditSeverity::Warning);
+        assert_eq!(AuditAction::AuthAttempt, AuditAction::AuthAttempt);
+        assert_ne!(AuditAction::AuthAttempt, AuditAction::ConfigChange);
 
         // Debug formatting.
         let dbg = format!("{:?}", AuditCategory::MountSecurity);
         assert!(dbg.contains("MountSecurity"));
         let dbg = format!("{:?}", AuditSeverity::Warning);
         assert!(dbg.contains("Warning"));
+        let dbg = format!("{:?}", AuditAction::ShellExec);
+        assert!(dbg.contains("ShellExec"));
     }
 }

--- a/src/kernel/gate.rs
+++ b/src/kernel/gate.rs
@@ -33,7 +33,7 @@ fn audit_actor_id(ctx: &ToolContext) -> String {
 
 fn audit_specific_action(name: &str) -> Option<AuditAction> {
     match name {
-        "shell" => Some(AuditAction::ShellExec),
+        "shell" | "shell_execute" => Some(AuditAction::ShellExec),
         "web_fetch" | "web_search" => Some(AuditAction::NetworkAccess),
         "spawn" | "delegate" => Some(AuditAction::AgentSpawn),
         _ => None,
@@ -245,11 +245,23 @@ mod tests {
     fn test_audit_specific_action_classification() {
         assert_eq!(audit_specific_action("shell"), Some(AuditAction::ShellExec));
         assert_eq!(
+            audit_specific_action("shell_execute"),
+            Some(AuditAction::ShellExec)
+        );
+        assert_eq!(
             audit_specific_action("web_fetch"),
             Some(AuditAction::NetworkAccess)
         );
         assert_eq!(
+            audit_specific_action("web_search"),
+            Some(AuditAction::NetworkAccess)
+        );
+        assert_eq!(
             audit_specific_action("spawn"),
+            Some(AuditAction::AgentSpawn)
+        );
+        assert_eq!(
+            audit_specific_action("delegate"),
             Some(AuditAction::AgentSpawn)
         );
         assert_eq!(audit_specific_action("echo"), None);

--- a/src/kernel/gate.rs
+++ b/src/kernel/gate.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use std::sync::RwLock;
 use std::time::Instant;
 
+use crate::audit::{record_audit_chain_event, AuditAction};
 use crate::error::Result;
 use crate::safety::taint::TaintEngine;
 use crate::safety::{CheckDirection, SafetyLayer, SafetyResult, ScanOptions};
@@ -20,6 +21,31 @@ use crate::tools::{ToolContext, ToolOutput, ToolRegistry};
 use crate::utils::metrics::MetricsCollector;
 
 const FILE_BODY_IGNORED_POLICY_RULES: &[&str] = &["shell_injection"];
+
+fn audit_actor_id(ctx: &ToolContext) -> String {
+    match (&ctx.channel, &ctx.chat_id) {
+        (Some(channel), Some(chat_id)) => format!("{channel}:{chat_id}"),
+        (Some(channel), None) => channel.clone(),
+        _ => "system".to_string(),
+    }
+}
+
+fn audit_specific_action(name: &str) -> Option<AuditAction> {
+    match name {
+        "shell" => Some(AuditAction::ShellExec),
+        "web_fetch" | "web_search" => Some(AuditAction::NetworkAccess),
+        "spawn" | "delegate" => Some(AuditAction::AgentSpawn),
+        _ => None,
+    }
+}
+
+fn record_tool_execution_audit(actor_id: &str, name: &str, outcome: &str) {
+    let detail = format!("tool={name}");
+    record_audit_chain_event(actor_id, AuditAction::ToolInvoke, &detail, outcome);
+    if let Some(action) = audit_specific_action(name) {
+        record_audit_chain_event(actor_id, action, &detail, outcome);
+    }
+}
 
 fn blocked_input_output(name: &str, result: SafetyResult) -> ToolOutput {
     ToolOutput::error(format!(
@@ -113,6 +139,7 @@ pub async fn execute_tool(
     taint: Option<&RwLock<TaintEngine>>,
 ) -> Result<ToolOutput> {
     let start = Instant::now();
+    let actor_id = audit_actor_id(ctx);
 
     // Step 1: Safety check on input
     //
@@ -121,6 +148,7 @@ pub async fn execute_tool(
     // rule that false-positives on legitimate code snippets.
     if let Some(safety_layer) = safety {
         if let Some(result) = scan_tool_input(safety_layer, name, &input) {
+            record_tool_execution_audit(&actor_id, name, "blocked_input_safety");
             metrics.record_tool_call(name, start.elapsed(), false);
             return Ok(blocked_input_output(name, result));
         }
@@ -130,6 +158,7 @@ pub async fn execute_tool(
     if let Some(taint_mutex) = taint {
         if let Ok(engine) = taint_mutex.read() {
             if let Err(violation) = engine.check_sink(name, &input) {
+                record_tool_execution_audit(&actor_id, name, "blocked_taint");
                 metrics.record_tool_call(name, start.elapsed(), false);
                 return Ok(ToolOutput::error(format!(
                     "Tool '{}' blocked by taint tracking: {}",
@@ -143,6 +172,7 @@ pub async fn execute_tool(
     let output = match registry.execute_with_context(name, input, ctx).await {
         Ok(output) => output,
         Err(e) => {
+            record_tool_execution_audit(&actor_id, name, "execution_error");
             metrics.record_tool_call(name, start.elapsed(), false);
             return Err(e);
         }
@@ -152,6 +182,7 @@ pub async fn execute_tool(
     if let Some(safety_layer) = safety {
         let result = safety_layer.scan(&output.for_llm, CheckDirection::Output);
         if result.blocked {
+            record_tool_execution_audit(&actor_id, name, "blocked_output_safety");
             metrics.record_tool_call(name, start.elapsed(), false);
             return Ok(ToolOutput::error(format!(
                 "Tool '{}' output blocked by safety: {}",
@@ -169,6 +200,12 @@ pub async fn execute_tool(
     }
 
     // Step 6: Record metrics
+    let outcome = if output.is_error {
+        "tool_error"
+    } else {
+        "success"
+    };
+    record_tool_execution_audit(&actor_id, name, outcome);
     metrics.record_tool_call(name, start.elapsed(), !output.is_error);
 
     Ok(output)

--- a/src/kernel/gate.rs
+++ b/src/kernel/gate.rs
@@ -26,7 +26,8 @@ fn audit_actor_id(ctx: &ToolContext) -> String {
     match (&ctx.channel, &ctx.chat_id) {
         (Some(channel), Some(chat_id)) => format!("{channel}:{chat_id}"),
         (Some(channel), None) => channel.clone(),
-        _ => "system".to_string(),
+        (None, Some(chat_id)) => format!("chat:{chat_id}"),
+        (None, None) => "system".to_string(),
     }
 }
 
@@ -41,10 +42,8 @@ fn audit_specific_action(name: &str) -> Option<AuditAction> {
 
 fn record_tool_execution_audit(actor_id: &str, name: &str, outcome: &str) {
     let detail = format!("tool={name}");
-    record_audit_chain_event(actor_id, AuditAction::ToolInvoke, &detail, outcome);
-    if let Some(action) = audit_specific_action(name) {
-        record_audit_chain_event(actor_id, action, &detail, outcome);
-    }
+    let action = audit_specific_action(name).unwrap_or(AuditAction::ToolInvoke);
+    record_audit_chain_event(actor_id, action, &detail, outcome);
 }
 
 fn blocked_input_output(name: &str, result: SafetyResult) -> ToolOutput {
@@ -233,6 +232,27 @@ mod tests {
         registry.register(Box::new(WriteFileTool));
         registry.register(Box::new(EditFileTool));
         registry
+    }
+
+    #[test]
+    fn test_audit_actor_id_preserves_chat_only_context() {
+        let mut ctx = ToolContext::default();
+        ctx.chat_id = Some("chat-42".to_string());
+        assert_eq!(audit_actor_id(&ctx), "chat:chat-42");
+    }
+
+    #[test]
+    fn test_audit_specific_action_classification() {
+        assert_eq!(audit_specific_action("shell"), Some(AuditAction::ShellExec));
+        assert_eq!(
+            audit_specific_action("web_fetch"),
+            Some(AuditAction::NetworkAccess)
+        );
+        assert_eq!(
+            audit_specific_action("spawn"),
+            Some(AuditAction::AgentSpawn)
+        );
+        assert_eq!(audit_specific_action("echo"), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add an in-memory SHA-256 hash chain in src/audit.rs with append, tip, recent, and integrity verification APIs
- wire kernel::execute_tool() to record ToolInvoke entries for every call and classify shell/network/spawn calls with specific audit actions
- keep existing structured audit events intact while adding bounded detail/outcome fields for chain entries
- update AGENTS.md and CLAUDE.md snapshot notes

## Validation
- cargo clippy -- -D warnings
- cargo fmt -- --check
- cargo test -q audit::tests::test_hash_chain_record_and_verify
- cargo test -q audit::tests::test_hash_chain_detects_tampering
- cargo test -q audit::tests::test_hash_chain_recent_and_tip
- cargo test -q kernel::gate::tests::test_execute_tool_basic
- cargo test -q kernel::gate::tests::test_execute_tool_not_found

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory SHA-256 audit hash chain for tool executions with sequencing, RFC3339 UTC timestamps, bounded retention, and current-tip tracking.
  * Tool execution instrumentation now emits classified audit events (shell, network, spawn, generic), records actor identity fallbacks, and logs per-call outcomes including failures and success.

* **Tests**
  * Expanded test coverage for recording, integrity verification, recent-entry behavior, retention limits, classification, and tamper detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->