### PR TITLE
chore(deps): bump EmbarkStudios/cargo-deny-action from 2.0.15 to 2.0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
+      - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
 
   feature-matrix:
     name: Feature gates


### PR DESCRIPTION
## Summary

Cherry-pick of #521 under an author-owned branch so it can be merged.

Same diff as the dependabot PR — 1 line in \`.github/workflows/ci.yml\`
bumping \`EmbarkStudios/cargo-deny-action\` from 2.0.15 to 2.0.16.
The dependabot OAuth app hit the "workflow scope" rule wall on admin
merge, so this branch is pushed via SSH (user scope) instead.

Closes #521.

Co-Authored-By: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->