### PR TITLE
feat(providers): add Liquid AI (LFM2) as OpenAI-compatible provider

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -616,6 +616,22 @@ impl Config {
                 .api_base = Some(val);
         }
 
+        // Liquid AI
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_LIQUID_API_KEY")
+            .or_else(|_| std::env::var("LIQUID_API_KEY"))
+        {
+            self.providers
+                .liquid
+                .get_or_insert_with(ProviderConfig::default)
+                .api_key = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_LIQUID_API_BASE") {
+            self.providers
+                .liquid
+                .get_or_insert_with(ProviderConfig::default)
+                .api_base = Some(val);
+        }
+
         // Per-provider model overrides
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_ANTHROPIC_MODEL") {
             self.providers
@@ -704,6 +720,12 @@ impl Config {
         if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_NOVITA_MODEL") {
             self.providers
                 .novita
+                .get_or_insert_with(ProviderConfig::default)
+                .model = Some(val);
+        }
+        if let Ok(val) = std::env::var("ZEPTOCLAW_PROVIDERS_LIQUID_MODEL") {
+            self.providers
+                .liquid
                 .get_or_insert_with(ProviderConfig::default)
                 .model = Some(val);
         }
@@ -2344,6 +2366,22 @@ mod tests {
             Some("qf-test-env-key")
         );
         std::env::remove_var("ZEPTOCLAW_PROVIDERS_QIANFAN_API_KEY");
+    }
+
+    #[test]
+    fn test_liquid_env_override_api_key() {
+        std::env::set_var("ZEPTOCLAW_PROVIDERS_LIQUID_API_KEY", "liquid-test-env-key");
+        let mut config = Config::default();
+        config.apply_env_overrides();
+        assert_eq!(
+            config
+                .providers
+                .liquid
+                .as_ref()
+                .and_then(|p| p.api_key.as_deref()),
+            Some("liquid-test-env-key")
+        );
+        std::env::remove_var("ZEPTOCLAW_PROVIDERS_LIQUID_API_KEY");
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1576,6 +1576,9 @@ pub struct ProvidersConfig {
     /// Novita AI configuration (OpenAI-compatible endpoint).
     #[serde(default)]
     pub novita: Option<ProviderConfig>,
+    /// Liquid AI configuration (OpenAI-compatible, LFM2 model family — edge-optimized).
+    #[serde(default)]
+    pub liquid: Option<ProviderConfig>,
     /// Retry behavior for runtime provider calls
     pub retry: RetryConfig,
     /// Fallback behavior across multiple configured runtime providers

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -56,6 +56,7 @@ pub const RUNTIME_SUPPORTED_PROVIDERS: &[&str] = &[
     "xai",
     "qianfan",
     "novita",
+    "liquid",
 ];
 
 use crate::error::ProviderError;

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -223,6 +223,16 @@ pub const PROVIDER_REGISTRY: &[ProviderSpec] = &[
         default_api_version: None,
         api_key_required: true,
     },
+    ProviderSpec {
+        name: "liquid",
+        model_keywords: &["liquid", "lfm", "lfm2"],
+        runtime_supported: true,
+        default_base_url: Some("https://labs.liquid.ai/api/v1"),
+        backend: "openai",
+        default_auth_header: None,
+        default_api_version: None,
+        api_key_required: true,
+    },
 ];
 
 pub fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a ProviderConfig> {
@@ -244,6 +254,7 @@ pub fn provider_config_by_name<'a>(config: &'a Config, name: &str) -> Option<&'a
         "xai" => config.providers.xai.as_ref(),
         "qianfan" => config.providers.qianfan.as_ref(),
         "novita" => config.providers.novita.as_ref(),
+        "liquid" => config.providers.liquid.as_ref(),
         _ => None,
     }
 }
@@ -1052,6 +1063,38 @@ mod tests {
         assert_eq!(
             selected.api_base.as_deref(),
             Some("https://api.novita.ai/openai")
+        );
+    }
+
+    #[test]
+    fn test_liquid_resolves_with_default_base_url() {
+        let mut config = Config::default();
+        config.providers.liquid = Some(ProviderConfig {
+            api_key: Some("liquid-test-key".to_string()),
+            ..Default::default()
+        });
+
+        let selected = resolve_runtime_provider(&config).expect("provider should resolve");
+        assert_eq!(selected.name, "liquid");
+        assert_eq!(selected.backend, "openai");
+        assert_eq!(
+            selected.api_base.as_deref(),
+            Some("https://labs.liquid.ai/api/v1")
+        );
+    }
+
+    #[test]
+    fn test_liquid_model_inference() {
+        // LFM family keywords should infer the Liquid provider.
+        assert_eq!(provider_name_for_model("lfm2-24b-a2b"), Some("liquid"));
+        assert_eq!(
+            provider_name_for_model("lfm2.5-1.2b-instruct"),
+            Some("liquid")
+        );
+        assert_eq!(provider_name_for_model("lfm-7b"), Some("liquid"));
+        assert_eq!(
+            provider_name_for_model("liquid/lfm2-8b-a1b"),
+            Some("liquid")
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds Liquid AI as a first-class OpenAI-compatible provider (base URL `https://labs.liquid.ai/api/v1`) — aligned with ZeptoClaw's edge/IoT thesis and the LFM2 model family (LFM2-1.2B-Tool, LFM2.5-1.2B-Instruct, LFM2-24B-A2B, etc.)
- Pure registry plumbing — no new provider code, no new dependencies, reuses existing OpenAI-compat infrastructure exactly like `novita` / `kimi` / `qianfan`
- Model keywords (`liquid`, `lfm`, `lfm2`) allow auto-inference from model IDs like `lfm2-24b-a2b`

## Related Issue

Closes #541

## Files changed (5 locations, 4 files)

1. `src/config/types.rs` — added `pub liquid: Option<ProviderConfig>` to `ProvidersConfig` with `#[serde(default)]`
2. `src/providers/registry.rs` — added `ProviderSpec` entry to `PROVIDER_REGISTRY` + match arm in `provider_config_by_name()`
3. `src/config/mod.rs` — added env handlers for `ZEPTOCLAW_PROVIDERS_LIQUID_{API_KEY,API_BASE,MODEL}` (with `LIQUID_API_KEY` fallback)
4. `src/providers/mod.rs` — added `"liquid"` to `RUNTIME_SUPPORTED_PROVIDERS` (required by the existing `test_runtime_supported_constant_stays_in_sync` sync test — this was the only deviation from the 5-location spec)
5. Tests: `test_liquid_resolves_with_default_base_url`, `test_liquid_model_inference` (in `registry.rs`), and `test_liquid_env_override_api_key` (in `config/mod.rs`)

## Pre-submit Checklist

- [x] I branched from `upstream/main`
- [x] This PR contains only commits related to this change
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo nextest run --lib` passes (3420 passed, 6 skipped)
- [x] `cargo test --doc` passes (128 passed)
- [x] I added or updated tests for my changes (3 new tests)
- [x] New constants/limits are shared (not duplicated across files)
- [x] No new dependencies unless necessary (we target ~6 MB binary)

## Security Considerations

N/A — adds a config-only provider entry; the Liquid AI API key is handled by the same env/config path as all existing providers, with the existing redaction and env-override precedence rules.

## Test Plan

Automated:
- `cargo nextest run --lib` — full suite green (3420/3420)
- `cargo test --doc` — 128 passed
- New tests cover: default base URL resolution, model-keyword inference for `lfm`/`lfm2`/`liquid`/`liquid/lfm2-*`, and `ZEPTOCLAW_PROVIDERS_LIQUID_API_KEY` env override

Smoke test (requires a Liquid Labs API key from https://labs.liquid.ai):

```bash
export LIQUID_API_KEY=<key>
cargo run --release -- agent --provider liquid --model lfm2-24b-a2b -m "ping"
# optional: test the tool-specialized 1.2B edge variant
cargo run --release -- agent --provider liquid --model lfm2-1.2b-tool -m "What is 2+2?"
```

Expected: normal chat completion response; tool calling works for `lfm2-*-tool` and `lfm2-24b-a2b` (native function calling per Liquid AI docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Liquid AI provider is now available for use in the application
  * Configuration support for API key, base URL, and model selection
  * Environment variables can override Liquid provider settings

* **Tests**
  * Added verification tests for Liquid provider configuration and model routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->