### PR TITLE
chore(ci): expand CI matrix for optional integration features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
           - "--features panel"
           - "--features tool-pdf"
           - "--features memory-hnsw"
+          - "--features channel-email"
+          - "--features google"
+          - "--features provider-vertex"
+          - "--features whatsapp-web"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
       matrix:
         features:
           - "--no-default-features"
+          - "--features memory-embedding"
+          - "--features screenshot"
           - "--features panel"
           - "--features tool-pdf"
           - "--features memory-hnsw"
@@ -88,6 +90,13 @@ jobs:
           - "--features google"
           - "--features provider-vertex"
           - "--features whatsapp-web"
+          - "--features hardware"
+          - "--features peripheral-rpi"
+          - "--features probe"
+          - "--features android"
+          - "--features sandbox-landlock"
+          - "--features sandbox-firejail"
+          - "--features sandbox-bubblewrap"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Project-level guidance for coding agents working in this repository.
 - r8r bridge: optional WebSocket client for workflow approvals, health updates, and replay-safe duplicate-event acknowledgments
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
 - Config validation: `zeptoclaw config check` recognizes top-level `tunnel` and `r8r_bridge`, plus agent defaults such as `timezone`, `tool_timeout_secs`, and `system_prompt`
+- CI feature gates now compile `channel-email`, `google`, `provider-vertex`, and `whatsapp-web` in addition to the lighter baseline feature matrix
 - MCP transport: supports both HTTP and stdio MCP servers (`url` or `command` + args/env) with tool registration during `create_agent()`
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
 - Panel CLI fallback: feature-disabled builds still parse `zeptoclaw panel ...` and return explicit `--features panel` guidance instead of a raw unknown-subcommand error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Project-level guidance for coding agents working in this repository.
 - r8r bridge: optional WebSocket client for workflow approvals, health updates, and replay-safe duplicate-event acknowledgments
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
 - Config validation: `zeptoclaw config check` recognizes top-level `tunnel` and `r8r_bridge`, plus agent defaults such as `timezone`, `tool_timeout_secs`, and `system_prompt`
-- CI feature gates now compile `channel-email`, `google`, `provider-vertex`, and `whatsapp-web` in addition to the lighter baseline feature matrix
+- CI feature gates now compile `memory-embedding`, `screenshot`, `channel-email`, `google`, `provider-vertex`, `whatsapp-web`, `hardware`, `peripheral-rpi`, `probe`, `android`, `sandbox-landlock`, `sandbox-firejail`, and `sandbox-bubblewrap` in addition to the lighter baseline feature matrix; `memory-bm25` and `peripheral-esp32` stay covered by dedicated test/clippy jobs
 - MCP transport: supports both HTTP and stdio MCP servers (`url` or `command` + args/env) with tool registration during `create_agent()`
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
 - Panel CLI fallback: feature-disabled builds still parse `zeptoclaw panel ...` and return explicit `--features panel` guidance instead of a raw unknown-subcommand error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ For detailed module docs see `docs/claude/architecture.md`.
 - The OpenAI-compatible `/v1/chat/completions` serve path forwards request tools, returns OpenAI-style tool-call payloads for assistant/tool messages, and the default provider streaming adapter now emits a text delta plus tool-call events before `Done` so non-native streaming providers are not silently flattened.
 - The serve API only accepts omitted, `null`, or `"auto"` for `tool_choice`; unsupported values are rejected with `400` instead of being ignored.
 - `src/audit.rs` now includes an in-memory SHA-256 hash chain (`record_audit_chain_event`, `verify_audit_chain_integrity`, `recent_audit_entries`, `audit_tip_hash`), and `kernel::execute_tool()` records per-call audit entries including shell/network/spawn classifications.
+- The CI feature-matrix job now checks `channel-email`, `google`, `provider-vertex`, and `whatsapp-web`, so optional integration paths fail fast before merge instead of drifting behind the default build.
 - `shell` tool output is truncated at 2,000 lines / 50KB before it reaches the model context.
 - `grep` reports subprocess failures instead of collapsing them into "No matches found".
 - `edit_file` rejects empty `old_text` and accepts optional `expected_replacements` to guard exact-match edits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ For detailed module docs see `docs/claude/architecture.md`.
 - The OpenAI-compatible `/v1/chat/completions` serve path forwards request tools, returns OpenAI-style tool-call payloads for assistant/tool messages, and the default provider streaming adapter now emits a text delta plus tool-call events before `Done` so non-native streaming providers are not silently flattened.
 - The serve API only accepts omitted, `null`, or `"auto"` for `tool_choice`; unsupported values are rejected with `400` instead of being ignored.
 - `src/audit.rs` now includes an in-memory SHA-256 hash chain (`record_audit_chain_event`, `verify_audit_chain_integrity`, `recent_audit_entries`, `audit_tip_hash`), and `kernel::execute_tool()` records per-call audit entries including shell/network/spawn classifications.
-- The CI feature-matrix job now checks `channel-email`, `google`, `provider-vertex`, and `whatsapp-web`, so optional integration paths fail fast before merge instead of drifting behind the default build.
+- The CI feature-matrix job now checks `memory-embedding`, `screenshot`, `channel-email`, `google`, `provider-vertex`, `whatsapp-web`, `hardware`, `peripheral-rpi`, `probe`, `android`, `sandbox-landlock`, `sandbox-firejail`, and `sandbox-bubblewrap`, while `memory-bm25` and `peripheral-esp32` remain covered by dedicated test/clippy jobs; optional feature paths now fail fast before merge instead of drifting behind the default build.
 - `shell` tool output is truncated at 2,000 lines / 50KB before it reaches the model context.
 - `grep` reports subprocess failures instead of collapsing them into "No matches found".
 - `edit_file` rejects empty `old_text` and accepts optional `expected_replacements` to guard exact-match edits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,7 +4487,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -4526,12 +4526,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6609,6 +6611,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7224,6 +7239,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "ring",
  "rpassword",
  "rppal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ json5 = "1.3"
 # - rustls-tls: Pure Rust TLS implementation (smaller than native-tls)
 # - default-features = false: Excludes unnecessary features
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream", "multipart"], default-features = false }
+# Separate client binding for Google Workspace crates, which currently depend on reqwest 0.13.
+reqwest013 = { package = "reqwest", version = "0.13", features = ["json", "rustls", "stream", "multipart"], default-features = false, optional = true }
 
 # =============================================================================
 # HTML PARSING
@@ -313,7 +315,7 @@ sandbox-bubblewrap = []
 # Pulls in google-cloud-auth and its transitive google-cloud-gax / google-cloud-rpc stack.
 provider-vertex = ["dep:google-cloud-auth"]
 # Google Workspace tools (Gmail + Calendar) via gogcli-rs
-google = ["dep:gog-gmail", "dep:gog-calendar", "dep:gog-auth", "dep:gog-core"]
+google = ["dep:gog-gmail", "dep:gog-calendar", "dep:gog-auth", "dep:gog-core", "dep:reqwest013"]
 # Control panel API server + dashboard (axum, JWT, bcrypt)
 panel = ["dep:axum", "dep:tower-http", "dep:jsonwebtoken", "dep:bcrypt"]
 

--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -421,19 +421,20 @@ impl Channel for EmailChannel {
             let this_running = Arc::clone(&self.running);
 
             tokio::spawn(async move {
+                let loop_running = Arc::clone(&this_running);
                 let task_result = std::panic::AssertUnwindSafe(async move {
                     let channel = EmailChannel {
                         config,
                         base_config: BaseChannelConfig::new("email"),
                         bus,
-                        running: Arc::clone(&this_running),
+                        running: Arc::clone(&loop_running),
                         seen_ids,
                     };
 
                     let mut backoff = std::time::Duration::from_secs(1);
                     let max_backoff = std::time::Duration::from_secs(60);
 
-                    while this_running.load(Ordering::SeqCst) {
+                    while loop_running.load(Ordering::SeqCst) {
                         match channel.run_idle_session().await {
                             Ok(()) => break,
                             Err(e) => {

--- a/src/peripherals/i2c.rs
+++ b/src/peripherals/i2c.rs
@@ -16,32 +16,12 @@
 
 use super::board_profile::BoardProfile;
 use super::serial::SerialTransport;
+use super::validate_hex;
 use crate::error::{Result, ZeptoError};
 use crate::tools::{Tool, ToolCategory, ToolContext, ToolOutput};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::sync::Arc;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Validate that `hex` is a non-empty, even-length string of ASCII hex digits.
-pub(crate) fn validate_hex(hex: &str) -> std::result::Result<(), String> {
-    if hex.is_empty() {
-        return Err("Hex data must not be empty".into());
-    }
-    if !hex.len().is_multiple_of(2) {
-        return Err(format!(
-            "Hex data must have even length (got {} chars)",
-            hex.len()
-        ));
-    }
-    if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("Hex data must contain only hex digits (0-9, a-f, A-F)".into());
-    }
-    Ok(())
-}
 
 // ---------------------------------------------------------------------------
 // I2cScanTool

--- a/src/peripherals/mod.rs
+++ b/src/peripherals/mod.rs
@@ -42,6 +42,27 @@ pub use traits::Peripheral;
 
 use crate::tools::Tool;
 
+#[cfg(any(
+    feature = "hardware",
+    all(feature = "peripheral-rpi", target_os = "linux")
+))]
+/// Validate that `hex` is a non-empty, even-length string of ASCII hex digits.
+pub(crate) fn validate_hex(hex: &str) -> std::result::Result<(), String> {
+    if hex.is_empty() {
+        return Err("Hex data must not be empty".into());
+    }
+    if !hex.len().is_multiple_of(2) {
+        return Err(format!(
+            "Hex data must have even length (got {} chars)",
+            hex.len()
+        ));
+    }
+    if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Hex data must contain only hex digits (0-9, a-f, A-F)".into());
+    }
+    Ok(())
+}
+
 /// Create peripheral tools based on enabled features.
 ///
 /// When the `hardware` feature is disabled, returns an empty vec.

--- a/src/peripherals/rpi_i2c.rs
+++ b/src/peripherals/rpi_i2c.rs
@@ -13,7 +13,7 @@
 
 use crate::error::{Result, ZeptoError};
 use crate::peripherals::board_profile::RPI_PROFILE;
-use crate::peripherals::i2c::validate_hex;
+use crate::peripherals::validate_hex;
 use crate::tools::{Tool, ToolCategory, ToolContext, ToolOutput};
 use async_trait::async_trait;
 use serde_json::{json, Value};

--- a/src/peripherals/serial.rs
+++ b/src/peripherals/serial.rs
@@ -160,6 +160,7 @@ impl SerialPeripheral {
         })
     }
 
+    #[cfg(feature = "peripheral-esp32")]
     /// Get a clone of the shared transport for tool construction.
     pub(crate) fn transport(&self) -> Arc<SerialTransport> {
         self.transport.clone()

--- a/src/tools/google.rs
+++ b/src/tools/google.rs
@@ -1,7 +1,7 @@
 //! Google Workspace tool for Gmail and Calendar operations.
 
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest013::Client;
 use serde_json::{json, Value};
 
 use gog_calendar::create::{create_event, CreateParams};


### PR DESCRIPTION
## Summary

Cherry-pick of #544 (manelsen) under an author-owned branch — same OAuth \`workflow\` scope wall as #521/#542, resolved by SSH push.

Expands the CI feature-matrix to compile-check optional paths that previously drifted silently behind the default build:

\`memory-embedding\`, \`screenshot\`, \`channel-email\`, \`google\`, \`provider-vertex\`, \`whatsapp-web\`, \`hardware\`, \`peripheral-rpi\`, \`probe\`, \`android\`, \`sandbox-landlock\`, \`sandbox-firejail\`, \`sandbox-bubblewrap\`

The matrix expansion immediately surfaced two latent bugs that are also fixed here:

1. **\`src/channels/email_channel.rs\`** — use-after-move on \`Arc<AtomicBool>\` inside the \`AssertUnwindSafe\` panic-capture closure (only built under \`channel-email\`)
2. **\`src/peripherals/i2c.rs\` → \`mod.rs\`** — \`validate_hex\` lived under \`hardware\` but was used by \`rpi_i2c.rs\` under \`peripheral-rpi\`; moved up to the parent module with the right cfg gate
3. **\`src/peripherals/serial.rs\`** — \`transport()\` getter cfg-gated to \`peripheral-esp32\` (dead code under \`hardware\` alone)

\`google\` feature also pulls a separate \`reqwest013 = { package = "reqwest", version = "0.13" }\` since the \`gog-*\` crates are still on reqwest 0.13 while main is on 0.12 — clean version-conflict workaround, only when \`google\` is enabled.

Closes #544.

Co-Authored-By: manelsen <emanuelmoura@gmail.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI compilation matrix to verify additional feature combinations.
  * Added optional dependency for Google Workspace integration.

* **Refactor**
  * Consolidated hexadecimal validation logic into a shared utility.
  * Improved email IMAP task synchronization handling.

* **Tests**
  * Enhanced feature-gating coverage in continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->