### PR TITLE
feat(tools): trigger-phrase nudges in longterm_memory description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Project-level guidance for coding agents working in this repository.
 - Persona switching: `/persona` command with presets and custom text, LTM persistence per chat
 - CLI interactive mode: TTY-gated local slash commands with rustyline tab completion when available, persisted REPL history, inline tool approval prompts, session-scoped `/trust` override for local use, `/model` and `/persona` overrides, `/tools`, `/template`, and `/clear`
 - Memory injection: per-message query-matched injection via shared LTM on `AgentLoop` (startup static injection removed)
+- Long-term memory tool guidance: `longterm_memory` now advertises explicit use/counter-use trigger phrases so agents persist durable corrections and preferences without duplicating repo docs or task-scoped context
 - Tool execution convergence: agent loop, MCP server, and embedded `ZeptoAgent` facade all route through `kernel::execute_tool()` (shared safety scan + taint checks + single metrics recording); the facade also enforces per-tool timeout, panic capture, and optional approval handling for embedded coding backends
 - Coding tool hardening: `grep` now surfaces subprocess failures instead of silently returning "No matches"; `shell` truncates output at 2,000 lines / 50KB; `edit_file` rejects empty `old_text` and supports optional `expected_replacements` for safer surgical edits
 - Tool composition: natural language tool creation with `{{param}}` template interpolation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ For detailed module docs see `docs/claude/architecture.md`.
 - `shell` tool output is truncated at 2,000 lines / 50KB before it reaches the model context.
 - `grep` reports subprocess failures instead of collapsing them into "No matches found".
 - `edit_file` rejects empty `old_text` and accepts optional `expected_replacements` to guard exact-match edits.
+- `longterm_memory` includes explicit use/counter-use trigger phrases so durable user corrections, preferences, and project conventions are persisted only when they generalize beyond the current task.
 
 ## Common Tasks
 

--- a/src/tools/longterm_memory.rs
+++ b/src/tools/longterm_memory.rs
@@ -46,7 +46,24 @@ impl Tool for LongTermMemoryTool {
     }
 
     fn description(&self) -> &str {
-        "Store and retrieve long-term memories (facts, preferences, learnings) that persist across sessions. Use 'set' to remember something, 'get' to recall by key, 'search' to find memories by keyword."
+        "Store and retrieve long-term memories (facts, preferences, learnings) that persist across sessions. \
+Actions: 'set' to remember, 'get' to recall by key, 'search' to find by keyword, 'list' to enumerate, \
+'categories' to inspect groupings, 'delete' to remove, 'pin' to mark as never-forget.\n\
+\n\
+Use when:\n\
+- User corrects you (\"don't do that again\", \"remember this\", \"next time...\")\n\
+- User shares a non-obvious preference (\"I always want X\", \"never run Y here\")\n\
+- You discover an environment quirk worth recording (path, tool version, OS-specific gotcha)\n\
+- You learn a project-specific convention (commit format, branch naming, test runner choice)\n\
+- A multi-step approach worked and the user is likely to want it repeated\n\
+\n\
+Do NOT use when:\n\
+- The fact is already in CLAUDE.md, README, or repo code/comments — read those first\n\
+- The information is conversation-scoped (current task, ephemeral debugging context)\n\
+- The user has not signaled it should be persisted\n\
+- You are unsure whether it generalizes — ask first, save second\n\
+\n\
+Tip: call 'categories' before 'set' to reuse an existing category instead of creating a near-duplicate."
     }
 
     fn compact_description(&self) -> &str {
@@ -380,8 +397,34 @@ mod tests {
     #[test]
     fn test_tool_description() {
         let (tool, _dir) = temp_tool();
-        assert!(tool.description().contains("long-term memories"));
-        assert!(tool.description().contains("persist across sessions"));
+        let desc = tool.description();
+        assert!(desc.contains("long-term memories"));
+        assert!(desc.contains("persist across sessions"));
+    }
+
+    /// The description must include explicit trigger-phrase guidance so the
+    /// model knows *when* to call this tool, not just *how*. Removing this
+    /// block silently regresses memory-persistence behavior — guard it.
+    #[test]
+    fn test_tool_description_has_trigger_phrases() {
+        let (tool, _dir) = temp_tool();
+        let desc = tool.description();
+        assert!(
+            desc.contains("Use when:"),
+            "description must enumerate triggers"
+        );
+        assert!(
+            desc.contains("Do NOT use when:"),
+            "description must enumerate counter-triggers"
+        );
+        assert!(
+            desc.contains("remember this") || desc.contains("don't do that again"),
+            "description should reference the canonical user-correction phrases",
+        );
+        assert!(
+            desc.contains("CLAUDE.md") || desc.contains("README"),
+            "description should warn against duplicating repo-level docs",
+        );
     }
 
     #[test]

--- a/src/tools/longterm_memory.rs
+++ b/src/tools/longterm_memory.rs
@@ -58,10 +58,10 @@ Use when:\n\
 - A multi-step approach worked and the user is likely to want it repeated\n\
 \n\
 Do NOT use when:\n\
-- The fact is already in CLAUDE.md, README, or repo code/comments — read those first\n\
+- The fact is already in AGENTS.md, CLAUDE.md, README, or repo code/comments - read those first\n\
 - The information is conversation-scoped (current task, ephemeral debugging context)\n\
 - The user has not signaled it should be persisted\n\
-- You are unsure whether it generalizes — ask first, save second\n\
+- You are unsure whether it generalizes - ask first, save second\n\
 \n\
 Tip: call 'categories' before 'set' to reuse an existing category instead of creating a near-duplicate."
     }
@@ -404,7 +404,7 @@ mod tests {
 
     /// The description must include explicit trigger-phrase guidance so the
     /// model knows *when* to call this tool, not just *how*. Removing this
-    /// block silently regresses memory-persistence behavior — guard it.
+    /// block silently regresses memory-persistence behavior - guard it.
     #[test]
     fn test_tool_description_has_trigger_phrases() {
         let (tool, _dir) = temp_tool();
@@ -422,7 +422,7 @@ mod tests {
             "description should reference the canonical user-correction phrases",
         );
         assert!(
-            desc.contains("CLAUDE.md") || desc.contains("README"),
+            desc.contains("AGENTS.md") || desc.contains("CLAUDE.md") || desc.contains("README"),
             "description should warn against duplicating repo-level docs",
         );
     }

--- a/src/tools/longterm_memory.rs
+++ b/src/tools/longterm_memory.rs
@@ -417,13 +417,28 @@ mod tests {
             desc.contains("Do NOT use when:"),
             "description must enumerate counter-triggers"
         );
+        // One assertion per canonical phrase: `||` would let any all-but-one
+        // phrase be silently deleted while the test still passed, defeating
+        // the point of guarding the trigger block.
         assert!(
-            desc.contains("remember this") || desc.contains("don't do that again"),
-            "description should reference the canonical user-correction phrases",
+            desc.contains("remember this"),
+            "description must contain 'remember this' trigger phrase",
         );
         assert!(
-            desc.contains("AGENTS.md") || desc.contains("CLAUDE.md") || desc.contains("README"),
-            "description should warn against duplicating repo-level docs",
+            desc.contains("don't do that again"),
+            "description must contain \"don't do that again\" trigger phrase",
+        );
+        assert!(
+            desc.contains("AGENTS.md"),
+            "description must reference AGENTS.md as a counter-trigger",
+        );
+        assert!(
+            desc.contains("CLAUDE.md"),
+            "description must reference CLAUDE.md as a counter-trigger",
+        );
+        assert!(
+            desc.contains("README"),
+            "description must reference README as a counter-trigger",
         );
     }
 


### PR DESCRIPTION
## Summary

- Rewrite the `longterm_memory` tool's `description()` to enumerate concrete "Use when" / "Do NOT use when" triggers, mirroring the pattern used by Hermes Agent's `memory_tool.py`.
- Add a doc-test (`test_tool_description_has_trigger_phrases`) that guards the trigger block so future edits cannot silently strip it.

This is Phase 1.5 of adopting Hermes Agent's "self-improving loop" pattern — the **actual** nudge mechanism in Hermes is not a background agent, it's strong trigger-phrase language in tool descriptions. The model re-reads tool descriptions on every turn, so naming the triggers turns memory persistence into a reliable per-turn check rather than something the model forgets to do.

## Why

Today the description is functional but only tells the model *how* to call the tool, not *when*. The model only persists memories when explicitly told to. Adding concrete trigger phrases ("don't do that again", "remember this", "I always want X") aligns the description with the situations a user actually wants persisted, and the counter-triggers ("already in CLAUDE.md", "conversation-scoped") prevent over-persistence.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run --lib` — 3501 tests pass
- [x] `cargo test --doc` — 128 doc tests pass
- [x] New `test_tool_description_has_trigger_phrases` asserts the canonical phrases are present
- [x] Existing `test_tool_description` still passes

## Reference

- Hermes pattern: `tools/memory_tool.py` line ~518 (research summarised in chat 2026-05-03)
- Adoption plan: see issue #569 body

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for the long-term memory tool with explicit "Use when" and "Do NOT use when" trigger phrases.
  * Added concrete examples and phrasing to show appropriate vs. inappropriate uses.
  * Clarified that the tool only persists durable corrections/preferences when they generalize beyond the current task and to consult project docs first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->