### PR TITLE
fix(providers): keyword fallback must not claim unconfigured provider

### DIFF
--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -344,16 +344,36 @@ fn infer_provider_name_for_model(
         // Final fallback: keyword matching on the model suffix so that
         // "anthropic/claude-sonnet-4-6" can still resolve via "claude" keyword
         // when the prefix itself isn't a configured provider.
+        //
+        // IMPORTANT: when an availability context is supplied, only match
+        // providers the user has actually configured. Without this guard, a
+        // model id like "openai/gpt-oss-120b" routed through a non-OpenAI
+        // vendor (e.g. NVIDIA NIM's OpenAI-compatible catalog) incorrectly
+        // resolves to "openai" because the suffix contains the keyword
+        // "gpt". Runtime then tries to use the unconfigured OpenAI provider,
+        // yielding "Invalid API Key" loops.
+        //
+        // When `available_providers` is empty, callers explicitly opted out
+        // of availability checks (e.g. the legacy `provider_name_for_model`
+        // entry point), and the historical keyword-only behaviour is kept.
         return PROVIDER_REGISTRY
             .iter()
             .filter(|spec| spec.runtime_supported)
+            .filter(|spec| {
+                available_providers.is_empty() || available_providers.contains(&spec.name)
+            })
             .find(|spec| spec.model_keywords.iter().any(|kw| suffix.contains(kw)))
             .map(|spec| spec.name);
     }
 
+    // Same guard for unprefixed model ids: never claim a provider the user
+    // hasn't configured. When available_providers is empty (callers using
+    // provider_name_for_model without availability context), the historical
+    // keyword-only behaviour is preserved.
     PROVIDER_REGISTRY
         .iter()
         .filter(|spec| spec.runtime_supported)
+        .filter(|spec| available_providers.is_empty() || available_providers.contains(&spec.name))
         .find(|spec| {
             spec.model_keywords
                 .iter()
@@ -1345,5 +1365,53 @@ mod tests {
     fn test_provider_name_for_model_no_match() {
         assert_eq!(provider_name_for_model("some-unknown-model"), None);
         assert_eq!(provider_name_for_model(""), None);
+    }
+
+    #[test]
+    fn test_with_available_does_not_claim_unconfigured_provider_from_suffix_keyword() {
+        // Regression: "openai/gpt-oss-120b" served by NVIDIA NIM previously
+        // resolved to "openai" via the suffix-keyword fallback ("gpt-oss-120b"
+        // contains the "gpt" keyword) even when the OpenAI provider was not
+        // configured. Runtime then attempted to use the unconfigured OpenAI
+        // provider, producing "Invalid API Key" loops.
+        //
+        // Only the explicitly configured "nvidia" provider is available.
+        let configured = vec!["nvidia"];
+        assert_eq!(
+            provider_name_for_model_with_available("openai/gpt-oss-120b", &configured),
+            None,
+            "must not claim openai when only nvidia is configured"
+        );
+    }
+
+    #[test]
+    fn test_with_available_unprefixed_keyword_respects_availability() {
+        // Same guard for unprefixed ids: "gpt-4o" must not resolve to "openai"
+        // when the user has not configured OpenAI.
+        let configured = vec!["anthropic"];
+        assert_eq!(
+            provider_name_for_model_with_available("gpt-4o", &configured),
+            None,
+        );
+
+        // But it still resolves when openai IS configured.
+        let configured = vec!["openai"];
+        assert_eq!(
+            provider_name_for_model_with_available("gpt-4o", &configured),
+            Some("openai"),
+        );
+    }
+
+    #[test]
+    fn test_without_available_preserves_keyword_only_behaviour() {
+        // The legacy  (which passes an empty
+        // available-providers list) must keep working for callers that
+        // don't have availability context. Keyword-only matching still
+        // applies in that case.
+        assert_eq!(provider_name_for_model("gpt-4o"), Some("openai"));
+        assert_eq!(
+            provider_name_for_model("claude-sonnet-4-5"),
+            Some("anthropic")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `infer_provider_name_for_model` could return a provider the user hadn't configured, because its keyword-based final fallback ignored `available_providers`.
- In production this manifested as a 100% error rate on a NIM-served Photon instance: model id `openai/gpt-oss-120b` resolved to provider `"openai"` via the `"gpt"` keyword even though only `nvidia` was configured, then the agent loop tried to authenticate against an empty OpenAI credential pool and looped on "Invalid API Key".
- Adds an availability guard on both the prefixed and unprefixed inference paths. Empty `available_providers` preserves the legacy keyword-only contract.

## Related Issue

This is a fix without a tracked issue — please tell me if you'd prefer one filed first.

Adjacent: looks like the same shape as #170 ("agentctl launch opencode strips 'openai/' prefix") and #698 ("Expansion subagent calls fail with OpenRouter models due to provider prefix not stripped"), but the underlying mechanism here is the suffix-keyword fallback, not prefix stripping. Happy to consolidate or split if you'd rather.

## Reproduction

Configure only `providers.nvidia` (no `providers.openai`) and request a model id like `openai/gpt-oss-120b` (NVIDIA NIM's catalog re-exposes some OpenAI-named models). Before the fix:

```
WARN  Primary provider failed, falling back primary="openai" fallback="openai"
      error=Provider error: Model not found: 404 page not found
WARN  Primary provider error is non-recoverable, skipping fallback
      primary="openai -> openai"
      error=Provider error: Authentication error: Invalid API Key
```

The agent loop never reaches the configured NVIDIA provider because `infer_provider_name_for_model("openai/gpt-oss-120b", &["nvidia"])` returns `Some("openai")` rather than `None`.

## Fix

Two-line change to add `available_providers.contains(&spec.name)` to the `filter` chain in both the prefixed-id keyword fallback and the unprefixed-id keyword path. `available_providers.is_empty()` short-circuits the guard so the legacy `provider_name_for_model` entry point (which passes `&[]`) keeps its keyword-only behaviour. That preserves every existing call site and every existing test.

## Tests

Three new regression tests in `src/providers/registry.rs`:

- `test_with_available_does_not_claim_unconfigured_provider_from_suffix_keyword` — pins the production failure mode: `openai/gpt-oss-120b` with only `nvidia` available now returns `None`.
- `test_with_available_unprefixed_keyword_respects_availability` — same guarantee on the unprefixed path.
- `test_without_available_preserves_keyword_only_behaviour` — guard rail for the legacy `provider_name_for_model` contract.

All existing `providers::registry` tests still pass.

## Pre-submit Checklist

- [x] I branched from `upstream/main`
- [x] This PR contains only commits related to this change
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (no new warnings on touched code)
- [x] `cargo test --lib providers::registry` passes
- [x] I added or updated tests for my changes
- [x] No new dependencies

## Security Considerations

Not applicable — pure routing-logic fix. Reduces the chance of leaking a user's intent to an unconfigured provider; never widens what can be reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider resolution to respect available providers during keyword-based matching, preventing vendor-prefixed models from incorrectly resolving to unconfigured providers.
  * Added tests to ensure provider availability context is properly respected during fallback matching and backward compatibility is maintained.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qhkm/zeptoclaw/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->