### PR TITLE
chore(deps): fix 8 RustSec advisories (h2, quick-xml, lopdf, bcrypt, quinn-proto, crossbeam-epoch, anyhow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "aquamarine"
@@ -216,7 +216,7 @@ checksum = "a78dceaba06f029d8f4d7df20addd4b7370a30206e3926267ecda2915b0f3f66"
 dependencies = [
  "async-channel 2.5.0",
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
@@ -330,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -385,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,11 +404,11 @@ checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "a0cd0bd35a28836d528d2b58ad499bc3c5641d59379421b1be9eeb0c2f2b912a"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "blowfish",
  "getrandom 0.4.2",
  "subtle",
@@ -529,12 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ed067eb6c1f660bdb87c05efb964421d2ca262bae0296cdfe38cf0cd949a3e"
 dependencies = [
  "async-tungstenite",
- "base64",
+ "base64 0.22.1",
  "chromiumoxide_cdp",
  "chromiumoxide_types",
  "dunce",
@@ -865,7 +865,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1594,7 +1594,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "memchr",
 ]
 
@@ -1681,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1714,7 +1714,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f05d15cb2479a3cbbbe684b9f0831b2ae036d9faefd1eb08f21267275862f9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "bytemuck",
  "esp-idf-part",
@@ -1988,11 +1988,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2002,11 +2000,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2059,7 +2059,7 @@ name = "gog-auth"
 version = "0.1.0"
 source = "git+https://github.com/qhkm/gogcli-rs#d30a532b5d76ad578f0bd93f3918174f49318bd6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "gog-core",
  "gog-secrets",
@@ -2108,7 +2108,7 @@ name = "gog-gmail"
 version = "0.1.0"
 source = "git+https://github.com/qhkm/gogcli-rs#d30a532b5d76ad578f0bd93f3918174f49318bd6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "gog-api",
  "gog-core",
@@ -2139,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27e658fc9f8b6bdf9a5c816ebca6dd6bcd32f8550e5c6580652b2c0eac1980f6"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "google-cloud-gax",
@@ -2165,7 +2165,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dc387965cc2efc28d73896d6707125815c16792c23c33a0c67794f3d6e31cc8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "google-cloud-rpc",
@@ -2198,7 +2198,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ade65b0e4fa9cb4b6f147c8e726803bff453e3190910a53cbd3b0c019f5c2a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "serde",
  "serde_json",
@@ -2210,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2474,7 +2474,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2825,7 +2825,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -2996,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -3076,9 +3076,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lopdf"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fdcbab5b237a03984f83b1394dc534e0b1960675c7f3ec4d04dccc9032b56d"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags 2.11.0",
@@ -3094,7 +3094,6 @@ dependencies = [
  "log",
  "md-5",
  "nom 8.0.0",
- "nom_locate",
  "rand 0.10.1",
  "rangemap",
  "rayon",
@@ -3430,17 +3429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom_locate"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,7 +3656,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -4029,7 +4017,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031bed1313b45d93dae4ca8f0fee098530c6632e4ebd9e2769d5a49cdef273d3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.13.0",
  "jep106",
  "serde",
@@ -4163,9 +4151,9 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4192,15 +4180,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4357,6 +4346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,7 +4464,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4508,7 +4506,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4654,7 +4652,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4713,7 +4711,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5007,7 +5005,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5458,7 +5456,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5702,7 +5700,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -6134,7 +6132,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cookie_store",
  "log",
  "percent-encoding",
@@ -6153,7 +6151,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -6240,7 +6238,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "dashmap",
@@ -6310,7 +6308,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "ctr",
@@ -6728,7 +6726,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7201,7 +7199,7 @@ dependencies = [
  "async-imap",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bcrypt",
  "chacha20poly1305",
  "chromiumoxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ instant-distance = { version = "0.6.1", optional = true }
 # PDF (optional — feature-gated behind "tool-pdf")
 # =============================================================================
 # Pure-Rust PDF parser for text extraction
-lopdf = { version = "0.40", optional = true }
+lopdf = { version = "0.42", optional = true }
 
 # =============================================================================
 # CHANNELS
@@ -224,7 +224,7 @@ probe-rs = { version = "0.31", optional = true }
 # XML PARSING
 # =============================================================================
 # Fast XML parser for DOCX extraction and Android uiautomator dump parsing
-quick-xml = "0.39"
+quick-xml = "0.41"
 
 # =============================================================================
 # GLOB MATCHING

--- a/src/tools/docx_read.rs
+++ b/src/tools/docx_read.rs
@@ -146,14 +146,14 @@ impl DocxReadTool {
                 }
                 Ok(Event::Text(ref e))
                     if in_t => {
-                        e.xml_content()
+                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
                             .map(|d| output.push_str(&d))
                             .map_err(|e| ZeptoError::Tool(format!("XML decode error: {e}")))?;
                     }
                 Ok(Event::GeneralRef(ref e))
                     // Remove escaped entities if they can't be resolved
                     if in_t => {
-                        e.xml_content()
+                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
                             .map(|d| resolve_xml_entity(d.as_ref()).map(|r| output.push_str(r)))
                             .map_err(|e| ZeptoError::Tool(format!("XML decode error: {e}")))?;
                     }

--- a/src/tools/docx_read.rs
+++ b/src/tools/docx_read.rs
@@ -14,6 +14,9 @@ use crate::security::{revalidate_path, validate_path_in_workspace};
 
 use super::{Tool, ToolContext, ToolOutput};
 
+/// XML version assumed when decoding DOCX text runs (DOCX content is XML 1.0).
+const DOCX_XML_VERSION: quick_xml::XmlVersion = quick_xml::XmlVersion::Implicit1_0;
+
 /// Maximum DOCX file size accepted before extraction (50 MB).
 const MAX_DOCX_BYTES: u64 = 50 * 1024 * 1024;
 
@@ -146,14 +149,14 @@ impl DocxReadTool {
                 }
                 Ok(Event::Text(ref e))
                     if in_t => {
-                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        e.xml_content(DOCX_XML_VERSION)
                             .map(|d| output.push_str(&d))
                             .map_err(|e| ZeptoError::Tool(format!("XML decode error: {e}")))?;
                     }
                 Ok(Event::GeneralRef(ref e))
                     // Remove escaped entities if they can't be resolved
                     if in_t => {
-                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        e.xml_content(DOCX_XML_VERSION)
                             .map(|d| resolve_xml_entity(d.as_ref()).map(|r| output.push_str(r)))
                             .map_err(|e| ZeptoError::Tool(format!("XML decode error: {e}")))?;
                     }

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -99,8 +99,10 @@ impl PdfReadTool {
         let doc = Document::load(path)
             .map_err(|e| ZeptoError::Tool(format!("Failed to load PDF: {e}")))?;
         let mut text = String::new();
-        for page_id in doc.page_iter() {
-            if let Ok(page_text) = doc.extract_text(&[page_id.0]) {
+        // lopdf extract_text takes 1-based page ordinals, not object ids.
+        let page_count = doc.get_pages().len() as u32;
+        for page_number in 1..=page_count {
+            if let Ok(page_text) = doc.extract_text(&[page_number]) {
                 text.push_str(&page_text);
                 text.push('\n');
             }
@@ -203,6 +205,78 @@ mod tests {
 
     fn tool(workspace: &str) -> PdfReadTool {
         PdfReadTool::new(workspace.to_string())
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "tool-pdf")]
+    async fn test_extracts_text_from_real_pdf() {
+        // Round-trip smoke: build a real one-page PDF with lopdf itself, then
+        // verify the tool's lopdf parse path (Document::load + extract_text)
+        // reads the text back. Guards the RUSTSEC-2026-0187 upgrade surface.
+        use lopdf::content::{Content, Operation};
+        use lopdf::{dictionary, Document, Object, Stream, StringFormat};
+
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().to_str().unwrap();
+
+        let mut doc = Document::with_version("1.4");
+        let pages_id = doc.new_object_id();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+        });
+        let content = Content {
+            operations: vec![
+                Operation::new("BT", vec![]),
+                Operation::new("Tf", vec![Object::Name(b"F1".to_vec()), 14.into()]),
+                Operation::new("Td", vec![72.into(), 700.into()]),
+                Operation::new(
+                    "Tj",
+                    vec![Object::String(
+                        b"HelloSmoke".to_vec(),
+                        StringFormat::Literal,
+                    )],
+                ),
+                Operation::new("ET", vec![]),
+            ],
+        };
+        let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Contents" => content_id,
+            "Resources" => dictionary! {
+                "Font" => dictionary! { "F1" => font_id },
+            },
+        });
+        let pages_id = doc.add_object(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1,
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        let pdf_path = tmp.path().join("smoke.pdf");
+        doc.save(&pdf_path).unwrap();
+
+        let direct = PdfReadTool::extract_text(&pdf_path);
+        let text = direct.expect("lopdf should parse the generated PDF");
+        assert!(text.contains("HelloSmoke"), "extracted: {text:?}");
+
+        let t = tool(ws);
+        let ctx = ToolContext::default();
+        let result = t
+            .execute(serde_json::json!({"path": "smoke.pdf"}), &ctx)
+            .await
+            .unwrap();
+        assert!(
+            result.for_llm.contains("HelloSmoke"),
+            "expected extracted text in for_llm, got: {:?}",
+            result.for_llm
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #651

## Changes
- `cargo update`: h2 0.4.13→0.4.19 (RUSTSEC-2026-0258), bcrypt 0.19.1→0.19.3 (RUSTSEC-2026-0199), quinn-proto 0.11.14→0.11.17 (RUSTSEC-2026-0185), crossbeam-epoch 0.9.18→0.9.20 (RUSTSEC-2026-0204), anyhow 1.0.102→1.0.104 (RUSTSEC-2026-0190)
- Cargo.toml bumps: quick-xml 0.39→0.41 (RUSTSEC-2026-0194/0195), lopdf 0.40→0.42 (RUSTSEC-2026-0187)
- src/tools/docx_read.rs: `xml_content()` now takes `XmlVersion` (quick-xml 0.41 API) — passing `Implicit1_0` (DOCX internal XML is 1.0)

## Verification
- `cargo deny check advisories`: **ok** (was FAILED — unblocks #646)
- `cargo audit`: 0 vulnerabilities. Informational warnings remain (non-blocking, transitive): diesel + event-listener (unsound), proc-macro-error2 + ttf-parser (unmaintained)
- `cargo fmt --check`: clean · `cargo clippy -- -D warnings`: clean
- `cargo nextest run --lib`: 3509 passed, 5 skipped; 4 `tools::mcp::*_no_server` failures are pre-existing environment artifacts, unrelated to this change — this machine sets HTTP(S)_PROXY=127.0.0.1:10808, so reqwest receives `HTTP 502 Bad Gateway` from the local proxy instead of the expected connection error. Follow-up suggestion: set NO_PROXY=127.0.0.1 in those tests
- `cargo test --doc`: 128 passed, 0 failed, 27 ignored
- `cargo check --features tool-pdf`: clean (lopdf bump verified; tool-pdf is not covered by default gates)

## Notes
- lopdf 0.44 / quick-xml 0.42 exist but are beyond advisory scope — kept minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX text extraction compatibility with updated XML parsing behavior.
  * Fixed PDF text extraction to correctly process page numbers.
  * Maintained existing path validation, truncation, and document processing behavior.

* **Maintenance**
  * Updated PDF and XML parsing components to newer versions for improved compatibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->