### PR TITLE
fix(security): fail closed on invalid agent_mode (P0 #659)

### DIFF
--- a/src/security/agent_mode.rs
+++ b/src/security/agent_mode.rs
@@ -147,16 +147,17 @@ impl Default for AgentModeConfig {
 impl AgentModeConfig {
     /// Parse the configured mode string into an `AgentMode`.
     ///
-    /// Returns `Autonomous` if the string is invalid (with a tracing warning).
+    /// Returns the safe default (`Assistant`) if the string is invalid
+    /// (with a tracing warning). Never elevates to `Autonomous` on bad input.
     pub fn resolve(&self) -> AgentMode {
         self.mode.parse::<AgentMode>().unwrap_or_else(|_| {
             tracing::warn!(
                 mode = %self.mode,
-                "Unknown agent mode '{}', falling back to Autonomous. \
+                "Unknown agent mode '{}', falling back to the safe default 'assistant'. \
                  Valid values: observer, assistant, autonomous.",
                 self.mode
             );
-            AgentMode::Autonomous
+            AgentMode::Assistant
         })
     }
 }
@@ -369,9 +370,78 @@ mod tests {
         cfg.mode = "assistant".to_string();
         assert_eq!(cfg.resolve(), AgentMode::Assistant);
 
-        // Invalid falls back to Autonomous
-        cfg.mode = "garbage".to_string();
+        cfg.mode = "autonomous".to_string();
         assert_eq!(cfg.resolve(), AgentMode::Autonomous);
+
+        // Invalid values must fall back to the safe default (Assistant),
+        // never escalate to Autonomous. Regression: P0 fail-open.
+        for bad in [
+            "garbage",
+            "",
+            "ADMIN",
+            "freedom",
+            "auto",
+            "assistant ",
+            " autonomous",
+            "autonomous\n",
+            "🦀",
+        ] {
+            cfg.mode = bad.to_string();
+            assert_eq!(
+                cfg.resolve(),
+                AgentMode::Assistant,
+                "invalid mode {bad:?} must resolve to Assistant, not Autonomous"
+            );
+        }
+    }
+
+    /// Regression test for the P0 fail-open finding: no unknown agent mode
+    /// value may ever resolve to `Autonomous`.
+    #[test]
+    fn test_invalid_modes_never_resolve_to_autonomous() {
+        // Every reserved/powerful string that an attacker or typo might try.
+        let unknowns = [
+            "autonomous ",
+            "autonomousx",
+            "xautonomous",
+            "AUTONOMOUS ",
+            "full_access",
+            "full-access",
+            "superuser",
+            "root",
+            "god",
+            "unrestricted",
+            "admin",
+            "AGENT",
+            "null",
+            "none",
+            "unknown",
+            "default",
+            "random",
+            "0",
+            "1",
+            "true",
+            "false",
+            "  ",
+        ];
+        for bad in unknowns {
+            let cfg = AgentModeConfig {
+                mode: bad.to_string(),
+            };
+            assert_eq!(
+                cfg.resolve(),
+                AgentMode::Assistant,
+                "mode {bad:?} must fail closed to Assistant"
+            );
+        }
+        // And the empty-string case from a truncated config.
+        assert_eq!(
+            AgentModeConfig {
+                mode: String::new()
+            }
+            .resolve(),
+            AgentMode::Assistant
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #659

## Summary
`agent_mode` now **fails closed** on invalid values. Unknown/typo'd mode strings previously resolved to `Autonomous` (max permissions) — the exact opposite of the safe default. Now they resolve to `Assistant` with a warning, and invalid values never escalate permissions.

## Change
- `src/security/agent_mode.rs` — invalid mode detection now maps to a safe fallback (`Assistant`) instead of `Autonomous`
- Exhaustive-style regression test covering: garbage strings, empty, case variants, whitespace, unicode — asserts none ever resolve to `Autonomous`

## Test evidence
- 9-value regression test added (all valid modes + 6 invalid variants)
- Full suite: **3504 passed**, 1 failure — `gateway::container_agent::tests::test_proxy_end_to_end_with_mocked_docker_binary`, proven **pre-existing/environmental** (fails identically on the untouched branch; passes on the real checkout `~/ios/zeptoclaw` — it's a `/private/tmp` worktree-path artifact tripping the temp-dir guard, not a regression from this change)

## Context
P0 finding, Exec #1 in `docs/reviews/2026-09-06-hermes-comparison-review.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or unrecognized agent mode settings now safely default to **Assistant** mode instead of **Autonomous**.
  - Inputs with unknown, empty, or extra whitespace are prevented from enabling Autonomous mode.
  - A warning is recorded when an invalid mode setting is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->