### PR TITLE
fix(security): scrub inherited env in plugin/MCP spawn sites (P0 #660)

### DIFF
--- a/src/channels/plugin.rs
+++ b/src/channels/plugin.rs
@@ -209,10 +209,10 @@ impl Channel for ChannelPluginAdapter {
             .stderr(std::process::Stdio::piped())
             .current_dir(&self.plugin_dir);
 
-        // Set environment variables from manifest
-        for (key, value) in &self.manifest.env {
-            cmd.env(key, value);
-        }
+        // Scrub the inherited environment: never leak parent secrets into
+        // channel plugin subprocesses. Only the manifest-configured env
+        // vars are applied on top of a scrubbed snapshot.
+        crate::security::env::configure_environment(&mut cmd, Some(&self.manifest.env), &[]);
 
         let mut child = cmd.spawn().map_err(|e| {
             self.running.store(false, Ordering::SeqCst);
@@ -897,6 +897,79 @@ mod tests {
     }
 
     // ---- Start and stop with real binary ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_start_scrubs_inherited_secret_env() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Distinct var name so parallel tests don't clobber each other's
+        // process-global env.
+        let secret_name = "ZC_CONTRACT_SECRET_CHANNEL_TOKEN";
+        let secret_value = "hunter2-do-not-leak";
+        std::env::set_var(secret_name, secret_value);
+
+        let dir = TempDir::new().unwrap();
+        let marker_path = dir.path().join("marker.txt");
+        let binary_path = dir.path().join("channel-plugin-scrub");
+
+        // The plugin writes the value of the secret env var to a marker file
+        // on startup, then stays alive echoing JSON-RPC responses. Explicit
+        // manifest env (MARKER_FILE) is applied on top of the scrubbed env.
+        let script = format!(
+            "#!/bin/sh\nprintenv {secret} > \"$MARKER_FILE\"\nwhile read line; do echo '{{\"jsonrpc\":\"2.0\",\"result\":{{\"status\":\"ok\"}},\"id\":1}}'; done\n",
+            secret = secret_name
+        );
+        std::fs::write(&binary_path, script).unwrap();
+        std::fs::set_permissions(&binary_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut manifest_env = HashMap::new();
+        manifest_env.insert("MARKER_FILE".to_string(), marker_path.display().to_string());
+
+        let manifest = ChannelPluginManifest {
+            name: "scrub-test".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Scrub test".to_string(),
+            binary: "channel-plugin-scrub".to_string(),
+            env: manifest_env,
+            timeout_secs: 30,
+        };
+
+        let mut adapter = ChannelPluginAdapter::new(
+            manifest,
+            dir.path().to_path_buf(),
+            BaseChannelConfig::new("scrub-test"),
+        );
+
+        let result = adapter.start().await;
+        assert!(result.is_ok(), "start failed: {:?}", result);
+        assert!(adapter.is_running());
+
+        // Wait for the child to write the marker file (bounded wait).
+        // `printenv` with an unset var writes an empty file, so existence is
+        // the signal that the child has started and inspected its env.
+        let mut marker_found = false;
+        for _ in 0..100 {
+            if std::fs::read_to_string(&marker_path).is_ok() {
+                marker_found = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(marker_found, "child did not write marker file");
+        // A scrubbed child sees an empty/absent secret; the marker contains
+        // whatever the child's `printenv` returned.
+        let marker = std::fs::read_to_string(&marker_path).unwrap_or_default();
+        assert!(
+            !marker.contains(secret_value),
+            "secret leaked into channel plugin env: {marker:?}"
+        );
+
+        let _ = adapter.stop().await;
+        assert!(!adapter.is_running());
+
+        std::env::remove_var(secret_name);
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/src/security/env.rs
+++ b/src/security/env.rs
@@ -1,0 +1,215 @@
+//! Subprocess environment scrubbing for agent-controlled child processes.
+//!
+//! Agent-controlled subprocesses must never inherit the full parent
+//! environment, which contains secrets (API keys, tokens, database URLs,
+//! and so on). These helpers replace the inherited environment with a
+//! scrubbed snapshot: only non-sensitive inherited variables plus any
+//! explicitly configured values are passed to the child.
+
+use std::collections::HashMap;
+use std::ffi::OsStr;
+
+/// Environment variable names that are never inherited by agent-controlled
+/// subprocesses.
+const SENSITIVE_SEGMENTS: &[&str] = &[
+    "AUTH",
+    "COOKIE",
+    "CREDENTIAL",
+    "CREDENTIALS",
+    "KEY",
+    "PASS",
+    "PASSWD",
+    "PASSWORD",
+    "SECRET",
+    "SESSION",
+    "TOKEN",
+];
+
+/// Replace the inherited environment of `command` with a scrubbed snapshot,
+/// then apply explicitly configured values. Names in `passthrough` opt back
+/// into inheritance, including names that match the sensitive-name filter.
+///
+/// Explicit command-scoped values always win over inherited values.
+pub(crate) fn configure_environment(
+    command: &mut tokio::process::Command,
+    explicit: Option<&HashMap<String, String>>,
+    passthrough: &[String],
+) {
+    command.env_clear();
+
+    for (name, value) in std::env::vars_os() {
+        if should_inherit(&name, passthrough) {
+            command.env(name, value);
+        }
+    }
+
+    if let Some(explicit) = explicit {
+        for (name, value) in explicit {
+            command.env(name, value);
+        }
+    }
+}
+
+fn should_inherit(name: &OsStr, passthrough: &[String]) -> bool {
+    let name = name.to_string_lossy();
+    passthrough
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(&name))
+        || !is_sensitive_name(&name)
+}
+
+/// Returns true when `name` looks like a secret-bearing environment variable
+/// that must never be inherited by agent-controlled subprocesses.
+pub(crate) fn is_sensitive_name(name: &str) -> bool {
+    const SENSITIVE_SUFFIXES: &[&str] = &[
+        "_API_BASE",
+        "_API_KEY",
+        "_BASE_URL",
+        "_DSN",
+        "_PASSWORD",
+        "_SECRET",
+        "_TOKEN",
+        "DATABASE_URL",
+        "DB_URL",
+    ];
+
+    let upper = name.to_ascii_uppercase();
+    if SENSITIVE_SUFFIXES
+        .iter()
+        .any(|suffix| upper.ends_with(suffix))
+        || upper.contains("SERVICE_ACCOUNT")
+    {
+        return true;
+    }
+
+    // Single-segment catch-all: e.g. MYSECRET, MYTOKEN, SESSIONID — names
+    // with no separator that still end in a sensitive segment.
+    if SENSITIVE_SEGMENTS
+        .iter()
+        .any(|seg| upper.len() > seg.len() && upper.ends_with(seg))
+    {
+        return true;
+    }
+
+    upper
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|segment| !segment.is_empty())
+        .any(|segment| {
+            SENSITIVE_SEGMENTS
+                .iter()
+                .any(|sensitive| segment.eq_ignore_ascii_case(sensitive))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- is_sensitive_name ----
+
+    #[test]
+    fn sensitive_names_are_detected() {
+        let sensitive = [
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GITHUB_TOKEN",
+            "AWS_SECRET_ACCESS_KEY",
+            "MY_PASSWORD",
+            "PASSWD",
+            "DATABASE_URL",
+            "POSTGRES_DSN",
+            "STRIPE_SECRET",
+            "SESSION_COOKIE",
+            "AUTH_TOKEN",
+            "CREDENTIALS",
+            "SERVICE_ACCOUNT_JSON",
+            "MYAPP_API_BASE",
+            "FOO_BASE_URL",
+            "API_KEY",
+            "TOKEN",
+            "SECRET",
+            "PASSWORD",
+            "DB_URL",
+            "MYSECRET",
+            "my_lowercase_token",
+        ];
+        for name in sensitive {
+            assert!(
+                is_sensitive_name(name),
+                "expected {name:?} to be flagged sensitive"
+            );
+        }
+    }
+
+    #[test]
+    fn non_sensitive_names_are_allowed() {
+        let allowed = [
+            "PATH", "HOME", "LANG", "LC_ALL", "TERM", "SHELL", "USER", "LOGNAME", "TMPDIR",
+            "EDITOR", "PAGER", "DISPLAY", "PWD", "OLDPWD", "SHLVL", "ZC_DEBUG", "FOO_BAR",
+            "NODE_ENV",
+        ];
+        for name in allowed {
+            assert!(
+                !is_sensitive_name(name),
+                "expected {name:?} to be non-sensitive"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_and_short_names_are_non_sensitive() {
+        assert!(!is_sensitive_name(""));
+        assert!(!is_sensitive_name("K"));
+        assert!(!is_sensitive_name("_"));
+    }
+
+    // ---- configure_environment ----
+
+    #[tokio::test]
+    async fn scrub_strips_secrets_keeps_benign_and_applies_explicit() {
+        // Set a secret in the real parent env so we can prove it is not
+        // inherited by the child.
+        let secret_name = "ZC_SCRUB_TEST_TOKEN";
+        std::env::set_var(secret_name, "super-secret-value");
+        std::env::set_var("ZC_SCRUB_TEST_BENIGN", "keep-me");
+
+        let mut cmd = tokio::process::Command::new("env");
+        let mut explicit = HashMap::new();
+        explicit.insert("ZC_SCRUB_TEST_EXPLICIT".to_string(), "set-me".to_string());
+        explicit.insert(secret_name.to_string(), "explicit-wins".to_string());
+        configure_environment(&mut cmd, Some(&explicit), &[]);
+
+        let output = cmd.output().await.expect("spawn env failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // The inherited secret must not leak through.
+        assert!(
+            !stdout.contains("super-secret-value"),
+            "child inherited a secret: {stdout}"
+        );
+        // Benign inherited vars survive.
+        assert!(stdout.contains("ZC_SCRUB_TEST_BENIGN=keep-me"));
+        // Explicit values always win, even for sensitive names.
+        assert!(stdout.contains("ZC_SCRUB_TEST_EXPLICIT=set-me"));
+        assert!(stdout.contains("ZC_SCRUB_TEST_TOKEN=explicit-wins"));
+
+        std::env::remove_var(secret_name);
+        std::env::remove_var("ZC_SCRUB_TEST_BENIGN");
+    }
+
+    #[tokio::test]
+    async fn passthrough_opts_back_into_secret_inheritance() {
+        let secret_name = "ZC_SCRUB_TEST_PASSTHROUGH_TOKEN";
+        std::env::set_var(secret_name, "super-secret-value");
+
+        let mut cmd = tokio::process::Command::new("env");
+        let passthrough = vec![secret_name.to_string()];
+        configure_environment(&mut cmd, None, &passthrough);
+
+        let output = cmd.output().await.expect("spawn env failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("ZC_SCRUB_TEST_PASSTHROUGH_TOKEN=super-secret-value"));
+
+        std::env::remove_var(secret_name);
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod agent_mode;
 pub mod encryption;
+pub mod env;
 pub mod mount;
 pub mod pairing;
 pub mod path;

--- a/src/tools/binary_plugin.rs
+++ b/src/tools/binary_plugin.rs
@@ -160,12 +160,10 @@ impl Tool for BinaryPluginTool {
                 cmd.current_dir(workspace);
             }
 
-            // Set environment variables from tool def
-            if let Some(env_vars) = &self.def.env {
-                for (key, value) in env_vars {
-                    cmd.env(key, value);
-                }
-            }
+            // Scrub the inherited environment: never leak parent secrets
+            // (API keys, tokens, database URLs) into plugin subprocesses.
+            // Only the explicitly configured tool env vars are applied.
+            crate::security::env::configure_environment(&mut cmd, self.def.env.as_ref(), &[]);
 
             match cmd.spawn() {
                 Ok(child) => break child,
@@ -300,6 +298,13 @@ impl Tool for BinaryPluginTool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Template for a plugin script that echoes the value of a named env var
+    /// in its JSON-RPC result. The env var name is substituted for
+    /// `__SECRET_NAME__`. Used to verify that secrets set in the parent env
+    /// do not leak into plugin subprocesses.
+    const TEMPLATE_SECRET_ECHO: &str = r#"read input
+echo "{\"jsonrpc\":\"2.0\",\"result\":{\"output\":\"seen=$__SECRET_NAME__\"},\"id\":1}""#;
 
     /// Returns true when running as UID 0 (root).
     ///
@@ -612,6 +617,33 @@ echo "{\"jsonrpc\":\"2.0\",\"result\":{\"output\":\"FOO=$MY_TEST_VAR\"},\"id\":1
         let result = tool.execute(json!({}), &ctx).await;
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
         assert_eq!(result.unwrap().for_llm, "FOO=bar_value");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_execute_scrubs_inherited_secret_env() {
+        // A secret set in the parent process must never leak into the
+        // plugin subprocess's environment.
+        let secret_name = "ZC_CONTRACT_SECRET_BINARY_KEY";
+        let secret_value = "hunter2-do-not-leak";
+        std::env::set_var(secret_name, secret_value);
+
+        // The plugin script echoes the value of $ZC_CONTRACT_SECRET_API_KEY
+        // into its JSON-RPC output. A scrubbed child sees an empty string.
+        let script = TEMPLATE_SECRET_ECHO.replace("__SECRET_NAME__", secret_name);
+        let (_dir, script_path) = create_test_script(&script);
+
+        let tool = BinaryPluginTool::new(test_tool_def(), "test-plugin", script_path, 30);
+        let ctx = ToolContext::new();
+        let result = tool.execute(json!({}), &ctx).await;
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+
+        // If the secret leaked, the output would contain the secret value.
+        let output = result.unwrap().for_llm;
+        assert_eq!(output, "seen=", "secret leaked into plugin env: {output}");
+        assert!(!output.contains(secret_value));
+
+        std::env::remove_var(secret_name);
     }
 
     #[cfg(unix)]

--- a/src/tools/mcp/transport.rs
+++ b/src/tools/mcp/transport.rs
@@ -113,9 +113,10 @@ impl StdioTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null());
 
-        for (key, value) in env {
-            cmd.env(key, value);
-        }
+        // Scrub the inherited environment: never leak parent secrets into
+        // the MCP server subprocess; only the explicitly configured env
+        // vars are applied on top of a scrubbed snapshot.
+        crate::security::env::configure_environment(&mut cmd, Some(env), &[]);
 
         let mut child = cmd
             .spawn()
@@ -346,6 +347,63 @@ done
         )
         .await;
         assert!(result.is_err(), "Spawning nonexistent binary should fail");
+    }
+
+    #[tokio::test]
+    async fn test_stdio_transport_scrubs_inherited_secret_env() {
+        // A secret set in the parent process must never leak into the MCP
+        // server subprocess's environment.
+        let secret_name = "ZC_CONTRACT_SECRET_MCP_KEY";
+        let secret_value = "hunter2-do-not-leak";
+        std::env::set_var(secret_name, secret_value);
+
+        // The child expands the env var inside the framed response body.
+        // A scrubbed child sees an empty value.
+        let script = r#"
+while IFS= read -r line; do
+  line="${line%%$'\r'}"
+  if [[ "$line" == Content-Length:* ]]; then
+    cl="${line#Content-Length: }"
+  fi
+  if [[ -z "$line" ]]; then
+    body=$(dd bs=1 count="$cl" 2>/dev/null)
+    out="seen=${__SECRET__}"
+    resp="{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"output\":\"$out\"}}"
+    printf "Content-Length: %d\r\n\r\n%s" "${#resp}" "$resp"
+  fi
+done
+"#
+        .replace("__SECRET__", secret_name);
+        let transport =
+            StdioTransport::spawn("bash", &["-c".to_string(), script], &HashMap::new(), 10).await;
+        assert!(
+            transport.is_ok(),
+            "bash echo should spawn: {:?}",
+            transport.err()
+        );
+        let t = transport.unwrap();
+
+        let req = McpRequest::new(1, "initialize", None);
+        let resp = t.send(&req).await;
+        assert!(resp.is_ok(), "roundtrip should succeed: {:?}", resp.err());
+        let resp = resp.unwrap();
+
+        // If the secret leaked, the child's output would contain the secret
+        // value inside the result.output field.
+        let output = resp
+            .result
+            .as_ref()
+            .and_then(|r| r.get("output"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert_eq!(
+            output, "seen=",
+            "secret leaked into MCP subprocess env: {output}"
+        );
+        assert!(!output.contains(secret_value));
+
+        std::env::remove_var(secret_name);
+        let _ = t.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #660

## Summary
Agent-controlled subprocesses previously **inherited the full parent environment**, leaking secrets (API keys, tokens, database URLs) into plugin and MCP server processes. This PR scrubs inheritance at all three remaining unscrubbed spawn sites, complementing the runtime-level hardening.

## Change
New `security::env::configure_environment()`: clears inherited env, re-admits only non-sensitive variables (plus optional passthrough), then applies explicitly configured values. Wired into:
- `tools/binary_plugin.rs` (binary-mode plugin `execute`)
- `tools/mcp/transport.rs` (`StdioTransport::spawn`)
- `channels/plugin.rs` (`ChannelPluginAdapter::start`)

Manifest-configured env vars still apply on top of the scrubbed snapshot (explicit wins).

## Test evidence
- Contract tests at each site: set a secret in the parent env, verify the child does **not** see it
- Unit tests for the name filter + explicit-wins/passthrough semantics
- Full suite: **3511 passed**, 1 failure — same pre-existing environmental artifact as the sibling P0 PR (worktree under `/private/tmp` trips the temp-dir guard in `validate_docker_binary`; identical failure on the untouched zc-mode worktree, passes on the real checkout)

## Context
P0 finding, Exec #2 in `docs/reviews/2026-09-06-hermes-comparison-review.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved protection for plugin, tool, and MCP subprocesses by preventing inherited sensitive environment variables from being exposed.
  - Explicitly configured environment variables continue to be passed through as intended, while only approved non-sensitive settings are inherited.

- **Bug Fixes**
  - Fixed a potential secret-leak scenario affecting child processes launched by channels and integrations.
  - Added coverage to verify sensitive environment values remain unavailable to spawned processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->