### PR TITLE
fix(security): harden secret storage and dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Project-level guidance for coding agents working in this repository.
 - Config hot-reload: gateway polls config mtime every 30s and applies provider/channel/safety updates
 - Config validation: `zeptoclaw config check` recognizes top-level `tunnel` and `r8r_bridge`, plus agent defaults such as `timezone`, `tool_timeout_secs`, and `system_prompt`
 - CI feature gates now compile `memory-embedding`, `screenshot`, `channel-email`, `google`, `provider-vertex`, `whatsapp-web`, `hardware`, `peripheral-rpi`, `probe`, `android`, `sandbox-landlock`, `sandbox-firejail`, and `sandbox-bubblewrap` in addition to the lighter baseline feature matrix; `memory-bm25` and `peripheral-esp32` stay covered by dedicated test/clippy jobs
-- Dependency audit baseline: `cargo deny check` passes with patched `anyhow` 1.0.103, `bcrypt` 0.19.2, `crossbeam-epoch` 0.9.20, `quinn-proto` 0.11.15, `quick-xml` 0.41, and `lopdf` 0.42
+- Dependency audit baseline: `cargo deny check` passes with patched `anyhow` 1.0.103, `bcrypt` 0.19.2, `chacha20` 0.10.2, `crossbeam-epoch` 0.9.20, `h2` 0.4.19, `quinn-proto` 0.11.15, `quick-xml` 0.41, and `lopdf` 0.42
 - MCP transport: supports both HTTP and stdio MCP servers (`url` or `command` + args/env) with tool registration during `create_agent()`
 - Hands-lite: `HAND.toml` + bundled hands (`researcher`, `coder`, `monitor`) + `hand` CLI
 - Panel CLI fallback: feature-disabled builds still parse `zeptoclaw panel ...` and return explicit `--features panel` guidance instead of a raw unknown-subcommand error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Project-level guidance for coding agents working in this repository.
 - Coding tool hardening: `grep` now surfaces subprocess failures instead of silently returning "No matches"; `shell` truncates output at 2,000 lines / 50KB; `edit_file` rejects empty `old_text` and supports optional `expected_replacements` for safer surgical edits
 - Tool composition: natural language tool creation with `{{param}}` template interpolation
 - Filesystem hardening: filesystem write/edit tools now create parent directories one component at a time inside the workspace and use secure no-follow writes; mount validation rejects Unix regular-file mounts with multiple hard links in both blocked-path and allowlist flows; safety pre-scan keeps full path scanning while scanning file bodies with a narrow `shell_injection` carve-out instead of skipping content wholesale
+- Secret storage hardening: config and panel token writes use user-only permissions on Unix (0600 files and 0700 ZeptoClaw directories) and repair permissions left by older versions
 - Safer default execution posture: fresh configs now start in `agent_mode = "assistant"` with approvals enabled under the `require_for_dangerous` policy
 - Gateway startup guard: degrade after N crashes to prevent crash loops
 - Loop guard: SHA256 tool-call repetition detection with warn + circuit-breaker stop
@@ -62,7 +63,7 @@ Project-level guidance for coding agents working in this repository.
 - Panel CLI fallback: feature-disabled builds still parse `zeptoclaw panel ...` and return explicit `--features panel` guidance instead of a raw unknown-subcommand error
 - Uninstall CLI: `zeptoclaw uninstall` removes `~/.zeptoclaw`; `--remove-binary` deletes direct installs in `~/.local/bin` or `/usr/local/bin` and defers Homebrew/Cargo binaries to their package managers
 - Process exit codes: explicit `main` mapping for success (0) and error (1); uncaught panic/crash remains Rust default (101)
-- Tests: current local validation passes `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo nextest run --lib` (3519 passed, 6 skipped), and `cargo test --doc` (128 passed, 27 ignored)
+- Tests: current local validation passes `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo nextest run --lib` (3531 passed, 6 skipped), and `cargo test --doc` (128 passed, 27 ignored)
 
 ## Task Tracking Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/
 ├── security/    # Shell blocklist, path validation, secret encryption
 ├── session/     # Session persistence, history, auto-repair
 ├── tools/       # 33 built-in + MCP + plugins + android
-├── utils/       # sanitize, metrics, telemetry, cost
+├── utils/       # sanitize, secure filesystem writes, metrics, telemetry, cost
 └── main.rs      # Entry point → cli::run()
 
 panel/           # React + Vite dashboard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -859,7 +859,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1449,7 +1449,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2204,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2819,7 +2819,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3428,7 +3428,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "once_cell",
  "rustix",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4205,7 +4205,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4289,7 +4289,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -4636,7 +4636,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4695,7 +4695,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5170,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5201,6 +5201,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5440,7 +5441,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6710,7 +6711,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6818,15 +6819,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6858,28 +6850,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6895,12 +6870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6911,12 +6880,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6931,22 +6894,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6961,12 +6912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6977,12 +6922,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6997,12 +6936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7013,12 +6946,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/src/cli/panel.rs
+++ b/src/cli/panel.rs
@@ -1,7 +1,7 @@
 //! `zeptoclaw panel` command — install, start, auth management.
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use zeptoclaw::api::auth::generate_api_token;
 use zeptoclaw::api::config::PanelConfig;
@@ -9,6 +9,7 @@ use zeptoclaw::api::events::EventBus;
 use zeptoclaw::api::server::{start_server, AppState};
 use zeptoclaw::config::Config;
 use zeptoclaw::providers::openai::OpenAIProvider;
+use zeptoclaw::utils::secure_fs::{ensure_private_dir, restrict_private_file, write_private_file};
 
 /// Panel subcommands.
 #[derive(clap::Subcommand, Debug)]
@@ -114,8 +115,15 @@ fn token_path() -> PathBuf {
 ///
 /// If the token file already contains a non-empty token, it is returned as-is.
 /// Otherwise a fresh 64-char hex token is generated, persisted, and returned.
-async fn ensure_api_token(token_path: &PathBuf) -> Result<String> {
+async fn ensure_api_token(token_path: &Path) -> Result<String> {
+    if let Some(parent) = token_path.parent() {
+        ensure_private_dir(parent)
+            .with_context(|| format!("Failed to secure directory: {}", parent.display()))?;
+    }
+
     if token_path.exists() {
+        restrict_private_file(token_path)
+            .with_context(|| format!("Failed to secure token file: {}", token_path.display()))?;
         let token = tokio::fs::read_to_string(token_path)
             .await
             .with_context(|| format!("Failed to read token file: {}", token_path.display()))?;
@@ -126,15 +134,7 @@ async fn ensure_api_token(token_path: &PathBuf) -> Result<String> {
     }
 
     let token = generate_api_token();
-
-    if let Some(parent) = token_path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
-    }
-
-    tokio::fs::write(token_path, &token)
-        .await
+    write_private_file(token_path, token.as_bytes())
         .with_context(|| format!("Failed to write token file: {}", token_path.display()))?;
 
     Ok(token)
@@ -565,6 +565,32 @@ mod tests {
             token.len(),
             64,
             "must generate a new token when file is empty"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_ensure_api_token_repairs_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let token_dir = dir.path().join(".zeptoclaw");
+        std::fs::create_dir(&token_dir).unwrap();
+        std::fs::set_permissions(&token_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let tp = token_dir.join("panel.token");
+        std::fs::write(&tp, "existing-token").unwrap();
+        std::fs::set_permissions(&tp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let token = ensure_api_token(&tp).await.unwrap();
+
+        assert_eq!(token, "existing-token");
+        assert_eq!(
+            std::fs::metadata(&token_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&tp).unwrap().permissions().mode() & 0o777,
+            0o600
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,7 @@ pub use types::*;
 use crate::error::{Result, ZeptoError};
 use once_cell::sync::OnceCell;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use tracing::{error, warn};
 use url::Url;
@@ -1568,18 +1568,19 @@ impl Config {
 
     /// Save configuration to the default path
     pub fn save(&self) -> Result<()> {
+        crate::utils::secure_fs::ensure_private_dir(&Self::dir())?;
         self.save_to_path(&Self::path())
     }
 
     /// Save configuration to a specific path
-    pub fn save_to_path(&self, path: &PathBuf) -> Result<()> {
+    pub fn save_to_path(&self, path: &Path) -> Result<()> {
         // Ensure directory exists
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         let content = serde_json::to_string_pretty(self)?;
-        std::fs::write(path, content)?;
+        crate::utils::secure_fs::write_private_file(path, content.as_bytes())?;
         Ok(())
     }
 
@@ -2248,6 +2249,24 @@ mod tests {
 
         // Clean up
         fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_to_path_repairs_config_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("config.json");
+        std::fs::write(&config_path, "{}").unwrap();
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        Config::default().save_to_path(&config_path).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(config_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod cost;
 pub mod logging;
 pub mod metrics;
 pub mod sanitize;
+pub mod secure_fs;
 pub mod slo;
 pub mod string;
 pub mod telemetry;

--- a/src/utils/secure_fs.rs
+++ b/src/utils/secure_fs.rs
@@ -1,0 +1,107 @@
+//! Filesystem helpers for secret-bearing files and directories.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Create `path` if needed and restrict it to the current user on Unix.
+pub fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(())
+}
+
+/// Restrict an existing file to the current user on Unix.
+pub fn restrict_private_file(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+
+    #[cfg(not(unix))]
+    let _ = path;
+
+    Ok(())
+}
+
+/// Write a secret-bearing file with user-only permissions on Unix.
+///
+/// The creation mode protects new files immediately, while the explicit
+/// permission update also repairs files created by older versions.
+pub fn write_private_file(path: &Path, contents: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        if path.exists() {
+            restrict_private_file(path)?;
+        }
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents)?;
+        restrict_private_file(path)?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn private_directory_is_user_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("private");
+
+        ensure_private_dir(&path).unwrap();
+
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn private_file_creation_and_rewrite_are_user_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("secret");
+
+        write_private_file(&path, b"first").unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        write_private_file(&path, b"second").unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"second");
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}


### PR DESCRIPTION
Config and panel token files could inherit permissive umask modes, leaving provider credentials and bearer tokens readable by other local users. This change creates secret files as `0600`, secures ZeptoClaw-owned directories as `0700`, and repairs permissions on files created by older releases whenever they are saved or reused.

The shared helper retains normal filesystem behavior on non-Unix platforms. Regression tests cover new files and permission repair for config and panel token paths.

The first CI run also exposed a stale dependency-security baseline that a local cached advisory database missed. The lockfile now uses patched `h2 0.4.19` and non-yanked `chacha20 0.10.2`, restoring both hosted audit gates.

Validation:

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --features panel --bin zeptoclaw -- -D warnings`
- `cargo nextest run --lib` — 3531 passed, 6 skipped
- `cargo test --doc` — 128 passed, 27 ignored
- panel permission regression test with `--features panel`
- `cargo check --features panel,provider-vertex,tool-pdf,whatsapp-web`
- `cargo deny check`
- `cargo audit` — no vulnerabilities; four documented allowed warnings

Closes #652
Closes #651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Secret-bearing configuration and API token files are now stored with user-only permissions.
  * Parent directories are restricted to user-only access.
  * Existing files and directories with broader permissions are automatically corrected when saved or reused.
  * Secure handling is applied consistently when creating or updating protected files.

* **Tests**
  * Added coverage confirming secure permissions are created and repaired correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->