### PR TITLE
fix(panel): replace websocket bearer URLs with tickets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Project-level guidance for coding agents working in this repository.
 - Tool composition: natural language tool creation with `{{param}}` template interpolation
 - Filesystem hardening: filesystem write/edit tools now create parent directories one component at a time inside the workspace and use secure no-follow writes; mount validation rejects Unix regular-file mounts with multiple hard links in both blocked-path and allowlist flows; safety pre-scan keeps full path scanning while scanning file bodies with a narrow `shell_injection` carve-out instead of skipping content wholesale
 - Secret storage hardening: config and panel token writes use user-only permissions on Unix (0600 files and 0700 ZeptoClaw directories) and repair permissions left by older versions
+- Panel auth hardening: static bearer tokens use constant-time comparison, WebSocket connections exchange them for 30-second single-use tickets, and CLI output points to the token file instead of printing the secret
 - Safer default execution posture: fresh configs now start in `agent_mode = "assistant"` with approvals enabled under the `require_for_dangerous` policy
 - Gateway startup guard: degrade after N crashes to prevent crash loops
 - Loop guard: SHA256 tool-call repetition detection with warn + circuit-breaker stop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Project-level guidance for coding agents working in this repository.
 - Tool composition: natural language tool creation with `{{param}}` template interpolation
 - Filesystem hardening: filesystem write/edit tools now create parent directories one component at a time inside the workspace and use secure no-follow writes; mount validation rejects Unix regular-file mounts with multiple hard links in both blocked-path and allowlist flows; safety pre-scan keeps full path scanning while scanning file bodies with a narrow `shell_injection` carve-out instead of skipping content wholesale
 - Secret storage hardening: config and panel token writes use user-only permissions on Unix (0600 files and 0700 ZeptoClaw directories) and repair permissions left by older versions
-- Panel auth hardening: static bearer tokens use constant-time comparison, WebSocket connections exchange them for 30-second single-use tickets, and CLI output points to the token file instead of printing the secret
+- Panel auth hardening: static bearer tokens use constant-time comparison, WebSocket connections exchange them for bounded 30-second single-use tickets, and CLI output points to the token file instead of printing the secret
 - Safer default execution posture: fresh configs now start in `agent_mode = "assistant"` with approvals enabled under the `require_for_dangerous` policy
 - Gateway startup guard: degrade after N crashes to prevent crash loops
 - Loop guard: SHA256 tool-call repetition detection with warn + circuit-breaker stop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ cargo fmt && cargo clippy -- -D warnings && cargo nextest run --lib && cargo tes
 ```
 src/
 ├── agent/       # Agent loop, context builder, token budget, compaction
-├── api/         # Panel API server + OpenAI-compatible serve routes (axum)
+├── api/         # Panel API, one-time WebSocket auth tickets, and OpenAI-compatible routes (axum)
 ├── auth/        # OAuth (PKCE), token refresh, Claude CLI import
 ├── bus/         # Async message bus
 ├── channels/    # Telegram, Slack, Discord, Webhook, WhatsApp Web/Cloud, Lark, Email, Serial, ACP; MQTT parked

--- a/panel/src/hooks/useWebSocket.ts
+++ b/panel/src/hooks/useWebSocket.ts
@@ -1,7 +1,8 @@
 // Connects to /ws/events and maintains a bounded in-memory event log.
 // Auto-reconnects every 3 seconds on close/error.
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../lib/api'
 
 export interface PanelEvent {
   type: string
@@ -17,50 +18,61 @@ export function useWebSocket(maxEvents = 50) {
   // Track mount state to prevent reconnect after unmount
   const mounted = useRef(true)
 
-  const connect = useCallback(() => {
-    if (!mounted.current) return
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const authToken = localStorage.getItem('panel_token') ?? ''
-    const url = `${protocol}//${window.location.host}/ws/events${authToken ? `?auth=${encodeURIComponent(authToken)}` : ''}`
-    const ws = new WebSocket(url)
-    wsRef.current = ws
-
-    ws.onopen = () => {
-      if (mounted.current) setConnected(true)
-    }
-
-    ws.onclose = () => {
-      if (!mounted.current) return
-      setConnected(false)
-      reconnectTimer.current = setTimeout(connect, 3_000)
-    }
-
-    ws.onerror = () => {
-      ws.close()
-    }
-
-    ws.onmessage = (msg) => {
-      if (!mounted.current) return
-      try {
-        const event = JSON.parse(msg.data as string) as PanelEvent
-        // Inject a client-side timestamp if the server omits one
-        if (!event.ts) event.ts = new Date().toISOString()
-        setEvents((prev) => [event, ...prev].slice(0, maxEvents))
-      } catch {
-        // Ignore malformed frames
-      }
-    }
-  }, [maxEvents])
-
   useEffect(() => {
     mounted.current = true
-    connect()
+
+    async function connect() {
+      if (!mounted.current) return
+      try {
+        const { ticket } = await apiFetch<{ ticket: string }>('/api/auth/ws-ticket', {
+          method: 'POST',
+        })
+        if (!mounted.current) return
+
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+        const url = `${protocol}//${window.location.host}/ws/events?ticket=${encodeURIComponent(ticket)}`
+        const ws = new WebSocket(url)
+        wsRef.current = ws
+
+        ws.onopen = () => {
+          if (mounted.current) setConnected(true)
+        }
+
+        ws.onclose = () => {
+          if (!mounted.current) return
+          setConnected(false)
+          reconnectTimer.current = setTimeout(() => void connect(), 3_000)
+        }
+
+        ws.onerror = () => {
+          ws.close()
+        }
+
+        ws.onmessage = (msg) => {
+          if (!mounted.current) return
+          try {
+            const event = JSON.parse(msg.data as string) as PanelEvent
+            // Inject a client-side timestamp if the server omits one
+            if (!event.ts) event.ts = new Date().toISOString()
+            setEvents((prev) => [event, ...prev].slice(0, maxEvents))
+          } catch {
+            // Ignore malformed frames
+          }
+        }
+      } catch {
+        if (!mounted.current) return
+        setConnected(false)
+        reconnectTimer.current = setTimeout(() => void connect(), 3_000)
+      }
+    }
+
+    void connect()
     return () => {
       mounted.current = false
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       wsRef.current?.close()
     }
-  }, [connect])
+  }, [maxEvents])
 
   return { events, connected }
 }

--- a/panel/src/hooks/useWebSocket.ts
+++ b/panel/src/hooks/useWebSocket.ts
@@ -15,19 +15,17 @@ export function useWebSocket(maxEvents = 50) {
   const [connected, setConnected] = useState(false)
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Track mount state to prevent reconnect after unmount
-  const mounted = useRef(true)
 
   useEffect(() => {
-    mounted.current = true
+    let cancelled = false
 
     async function connect() {
-      if (!mounted.current) return
+      if (cancelled) return
       try {
         const { ticket } = await apiFetch<{ ticket: string }>('/api/auth/ws-ticket', {
           method: 'POST',
         })
-        if (!mounted.current) return
+        if (cancelled) return
 
         const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
         const url = `${protocol}//${window.location.host}/ws/events?ticket=${encodeURIComponent(ticket)}`
@@ -35,11 +33,11 @@ export function useWebSocket(maxEvents = 50) {
         wsRef.current = ws
 
         ws.onopen = () => {
-          if (mounted.current) setConnected(true)
+          if (!cancelled) setConnected(true)
         }
 
         ws.onclose = () => {
-          if (!mounted.current) return
+          if (cancelled) return
           setConnected(false)
           reconnectTimer.current = setTimeout(() => void connect(), 3_000)
         }
@@ -49,7 +47,7 @@ export function useWebSocket(maxEvents = 50) {
         }
 
         ws.onmessage = (msg) => {
-          if (!mounted.current) return
+          if (cancelled) return
           try {
             const event = JSON.parse(msg.data as string) as PanelEvent
             // Inject a client-side timestamp if the server omits one
@@ -60,7 +58,7 @@ export function useWebSocket(maxEvents = 50) {
           }
         }
       } catch {
-        if (!mounted.current) return
+        if (cancelled) return
         setConnected(false)
         reconnectTimer.current = setTimeout(() => void connect(), 3_000)
       }
@@ -68,7 +66,7 @@ export function useWebSocket(maxEvents = 50) {
 
     void connect()
     return () => {
-      mounted.current = false
+      cancelled = true
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       wsRef.current?.close()
     }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -5,6 +5,10 @@
 
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use subtle::ConstantTimeEq;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::error::{Result, ZeptoError};
@@ -40,11 +44,18 @@ pub fn generate_api_token() -> String {
 // Bearer token verification
 // ============================================================================
 
+/// Compare two security-sensitive strings without data-dependent early exits.
+///
+/// Length is not secret for the tokens compared by the panel API.
+pub(crate) fn constant_time_eq(left: &str, right: &str) -> bool {
+    bool::from(left.as_bytes().ct_eq(right.as_bytes()))
+}
+
 /// Verifies an `Authorization: Bearer <token>` header value against the
 /// expected token.
 ///
 /// Strips the `"Bearer "` prefix (case-sensitive, with a trailing space),
-/// then performs a constant-time-like string comparison via `==`.
+/// then performs a constant-time comparison.
 ///
 /// # Errors
 ///
@@ -56,10 +67,48 @@ pub fn verify_bearer_token(header: &str, expected: &str) -> Result<()> {
         .strip_prefix("Bearer ")
         .ok_or_else(|| ZeptoError::Unauthorized("missing Bearer prefix".to_string()))?;
 
-    if token == expected {
+    if constant_time_eq(token, expected) {
         Ok(())
     } else {
         Err(ZeptoError::Unauthorized("invalid API token".to_string()))
+    }
+}
+
+// ============================================================================
+// WebSocket tickets
+// ============================================================================
+
+/// Lifetime of a one-time WebSocket authentication ticket.
+pub const WS_TICKET_TTL: Duration = Duration::from_secs(30);
+
+/// In-memory store for short-lived, single-use WebSocket tickets.
+///
+/// Tickets are issued only through an authenticated HTTP endpoint. Their short
+/// lifetime and single-use behavior limit exposure in URL logs while keeping
+/// the long-lived API token or JWT out of them entirely.
+#[derive(Debug, Default)]
+pub struct WsTicketStore {
+    tickets: Mutex<HashMap<String, Instant>>,
+}
+
+impl WsTicketStore {
+    /// Issue a fresh ticket and discard any expired entries.
+    pub async fn issue(&self) -> String {
+        let now = Instant::now();
+        let ticket = generate_api_token();
+        let mut tickets = self.tickets.lock().await;
+        tickets.retain(|_, expires_at| *expires_at > now);
+        tickets.insert(ticket.clone(), now + WS_TICKET_TTL);
+        ticket
+    }
+
+    /// Consume a ticket exactly once, returning whether it was still valid.
+    pub async fn consume(&self, ticket: &str) -> bool {
+        self.tickets
+            .lock()
+            .await
+            .remove(ticket)
+            .is_some_and(|expires_at| expires_at > Instant::now())
     }
 }
 
@@ -233,6 +282,33 @@ mod tests {
             matches!(result, Err(ZeptoError::Unauthorized(_))),
             "lowercase 'bearer' prefix must be rejected"
         );
+    }
+
+    #[test]
+    fn test_constant_time_eq_rejects_mismatches() {
+        assert!(constant_time_eq("same-token", "same-token"));
+        assert!(!constant_time_eq("same-token", "other-token"));
+        assert!(!constant_time_eq("short", "longer"));
+    }
+
+    #[tokio::test]
+    async fn test_ws_ticket_is_single_use() {
+        let store = WsTicketStore::default();
+        let ticket = store.issue().await;
+
+        assert!(store.consume(&ticket).await);
+        assert!(!store.consume(&ticket).await);
+    }
+
+    #[tokio::test]
+    async fn test_expired_ws_ticket_is_rejected() {
+        let store = WsTicketStore::default();
+        store.tickets.lock().await.insert(
+            "expired".to_string(),
+            Instant::now() - Duration::from_secs(1),
+        );
+
+        assert!(!store.consume("expired").await);
     }
 
     // ------------------------------------------------------------------

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -6,6 +6,7 @@
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use subtle::ConstantTimeEq;
 use tokio::sync::Mutex;
@@ -80,6 +81,8 @@ pub fn verify_bearer_token(header: &str, expected: &str) -> Result<()> {
 
 /// Lifetime of a one-time WebSocket authentication ticket.
 pub const WS_TICKET_TTL: Duration = Duration::from_secs(30);
+/// Maximum number of issued WebSocket tickets awaiting consumption.
+pub const MAX_PENDING_WS_TICKETS: usize = 64;
 
 /// In-memory store for short-lived, single-use WebSocket tickets.
 ///
@@ -92,23 +95,50 @@ pub struct WsTicketStore {
 }
 
 impl WsTicketStore {
-    /// Issue a fresh ticket and discard any expired entries.
-    pub async fn issue(&self) -> String {
+    /// Issue a fresh ticket, or return `None` when the bounded store is full.
+    pub async fn issue(&self) -> Option<String> {
         let now = Instant::now();
-        let ticket = generate_api_token();
         let mut tickets = self.tickets.lock().await;
         tickets.retain(|_, expires_at| *expires_at > now);
+        if tickets.len() >= MAX_PENDING_WS_TICKETS {
+            return None;
+        }
+
+        let ticket = generate_api_token();
         tickets.insert(ticket.clone(), now + WS_TICKET_TTL);
-        ticket
+        Some(ticket)
     }
 
     /// Consume a ticket exactly once, returning whether it was still valid.
     pub async fn consume(&self, ticket: &str) -> bool {
-        self.tickets
-            .lock()
-            .await
+        let now = Instant::now();
+        let mut tickets = self.tickets.lock().await;
+        let is_valid = tickets
             .remove(ticket)
-            .is_some_and(|expires_at| expires_at > Instant::now())
+            .is_some_and(|expires_at| expires_at > now);
+        tickets.retain(|_, expires_at| *expires_at > now);
+        is_valid
+    }
+
+    /// Periodically remove expired tickets while the owning server is alive.
+    pub fn start_cleanup(self: &Arc<Self>) {
+        let store = Arc::downgrade(self);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(WS_TICKET_TTL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                let Some(store) = store.upgrade() else {
+                    break;
+                };
+                let now = Instant::now();
+                store
+                    .tickets
+                    .lock()
+                    .await
+                    .retain(|_, expires_at| *expires_at > now);
+            }
+        });
     }
 }
 
@@ -294,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_ws_ticket_is_single_use() {
         let store = WsTicketStore::default();
-        let ticket = store.issue().await;
+        let ticket = store.issue().await.expect("store has capacity");
 
         assert!(store.consume(&ticket).await);
         assert!(!store.consume(&ticket).await);
@@ -309,6 +339,16 @@ mod tests {
         );
 
         assert!(!store.consume("expired").await);
+    }
+
+    #[tokio::test]
+    async fn test_ws_ticket_store_enforces_capacity() {
+        let store = WsTicketStore::default();
+        for _ in 0..MAX_PENDING_WS_TICKETS {
+            assert!(store.issue().await.is_some());
+        }
+
+        assert!(store.issue().await.is_none());
     }
 
     // ------------------------------------------------------------------

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -98,7 +98,7 @@ pub fn validate_csrf_token(token: &str, secret: &str) -> bool {
 /// - `GET /api/health` — liveness probe, no auth required
 /// - `GET /api/csrf-token` — must be public so the caller can bootstrap
 /// - `POST /api/auth/login` — exchanges password for JWT
-/// - Any path starting with `/ws/` — WebSocket upgrade handshake
+/// - Any path starting with `/ws/` — the handler validates a one-time ticket
 ///
 /// Accepts two token forms:
 /// 1. Static API token configured at startup (`state.api_token`)
@@ -135,7 +135,7 @@ pub async fn auth_middleware(
             let token = &header[7..];
 
             // Accept static API token OR a valid JWT.
-            let is_valid = token == state.api_token
+            let is_valid = crate::api::auth::constant_time_eq(token, &state.api_token)
                 || crate::api::auth::validate_jwt(token, &state.jwt_secret).is_ok();
 
             if !is_valid {
@@ -200,6 +200,7 @@ mod tests {
             .route("/api/protected", get(|| async { "secret" }))
             .route("/api/protected", post(|| async { "mutate" }))
             .route("/api/auth/login", post(|| async { "login" }))
+            .route("/api/auth/ws-ticket", post(|| async { "ticket" }))
             .route("/ws/events", get(|| async { "ws" }))
             .route("/v1/models", get(|| async { "models" }))
             .route("/v1/chat/completions", post(|| async { "completions" }))
@@ -238,6 +239,34 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("/api/auth/login")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_ws_ticket_requires_auth() {
+        let app = make_app(make_state());
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/api/auth/ws-ticket")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_ws_ticket_accepts_authenticated_csrf_request() {
+        let state = make_state();
+        let csrf = generate_csrf_token(&state.jwt_secret);
+        let app = make_app(state);
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/api/auth/ws-ticket")
+            .header("authorization", "Bearer static-test-token")
+            .header("x-csrf-token", csrf)
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/src/api/routes/auth.rs
+++ b/src/api/routes/auth.rs
@@ -4,7 +4,12 @@
 //! short-lived HS256 JWT.  The JWT is subsequently accepted by the auth
 //! middleware on all protected endpoints.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::IntoResponse,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -25,6 +30,13 @@ pub struct LoginRequest {
 pub struct LoginResponse {
     /// HS256 JWT valid for 24 hours.
     pub token: String,
+}
+
+/// Successful response from `POST /api/auth/ws-ticket`.
+#[derive(Debug, Serialize)]
+pub struct WsTicketResponse {
+    /// Random ticket accepted once by `/ws/events` for 30 seconds.
+    pub ticket: String,
 }
 
 // ============================================================================
@@ -59,6 +71,19 @@ pub async fn login(
         // Password auth is not configured — callers must use a static API token.
         None => Err(StatusCode::NOT_FOUND),
     }
+}
+
+/// `POST /api/auth/ws-ticket` — issue a short-lived, single-use WebSocket ticket.
+///
+/// The normal auth and CSRF middleware protect this endpoint. This exchange
+/// prevents the caller's long-lived API token or JWT from appearing in a URL.
+pub async fn issue_ws_ticket(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    (
+        [(header::CACHE_CONTROL, "no-store")],
+        Json(WsTicketResponse {
+            ticket: state.ws_tickets.issue().await,
+        }),
+    )
 }
 
 // ============================================================================
@@ -147,5 +172,32 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_issue_ws_ticket_returns_single_use_ticket() {
+        let state = make_state_no_password();
+        let app = Router::new()
+            .route("/api/auth/ws-ticket", post(issue_ws_ticket))
+            .with_state(state.clone());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/auth/ws-ticket")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let ticket = json["ticket"].as_str().expect("ticket must be present");
+        assert!(state.ws_tickets.consume(ticket).await);
+        assert!(!state.ws_tickets.consume(ticket).await);
     }
 }

--- a/src/api/routes/auth.rs
+++ b/src/api/routes/auth.rs
@@ -77,13 +77,23 @@ pub async fn login(
 ///
 /// The normal auth and CSRF middleware protect this endpoint. This exchange
 /// prevents the caller's long-lived API token or JWT from appearing in a URL.
-pub async fn issue_ws_ticket(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    (
-        [(header::CACHE_CONTROL, "no-store")],
-        Json(WsTicketResponse {
-            ticket: state.ws_tickets.issue().await,
-        }),
-    )
+pub async fn issue_ws_ticket(State(state): State<Arc<AppState>>) -> axum::response::Response {
+    match state.ws_tickets.issue().await {
+        Some(ticket) => (
+            [(header::CACHE_CONTROL, "no-store")],
+            Json(WsTicketResponse { ticket }),
+        )
+            .into_response(),
+        None => (
+            StatusCode::TOO_MANY_REQUESTS,
+            [
+                (header::CACHE_CONTROL, "no-store"),
+                (header::RETRY_AFTER, "30"),
+            ],
+            "Too many pending WebSocket tickets",
+        )
+            .into_response(),
+    }
 }
 
 // ============================================================================
@@ -199,5 +209,29 @@ mod tests {
         let ticket = json["ticket"].as_str().expect("ticket must be present");
         assert!(state.ws_tickets.consume(ticket).await);
         assert!(!state.ws_tickets.consume(ticket).await);
+    }
+
+    #[tokio::test]
+    async fn test_issue_ws_ticket_returns_429_when_store_is_full() {
+        let state = make_state_no_password();
+        for _ in 0..crate::api::auth::MAX_PENDING_WS_TICKETS {
+            assert!(state.ws_tickets.issue().await.is_some());
+        }
+        let app = Router::new()
+            .route("/api/auth/ws-ticket", post(issue_ws_ticket))
+            .with_state(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/auth/ws-ticket")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.headers().get(header::RETRY_AFTER).unwrap(), "30");
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
     }
 }

--- a/src/api/routes/ws.rs
+++ b/src/api/routes/ws.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 
 /// GET /ws/events — upgrades to WebSocket, streams PanelEvents as JSON.
 ///
-/// Authentication: Browsers cannot set custom headers during the WebSocket
-/// upgrade handshake, so the `/ws/` path is exempt from the auth middleware.
-/// Instead, this handler validates the auth token from a `?auth=<token>`
-/// query parameter before upgrading.  Both static API tokens and valid JWTs
-/// are accepted.
+/// Authentication: Browsers first obtain a short-lived, single-use ticket from
+/// the authenticated `POST /api/auth/ws-ticket` endpoint, then supply it as the
+/// `?ticket=<ticket>` query parameter. The long-lived API token or JWT never
+/// appears in the WebSocket URL.
 ///
 /// Enforces a hard cap of [`AppState::MAX_WS_CONNECTIONS`] concurrent
 /// WebSocket connections via a semaphore stored in [`AppState`].  When the
@@ -24,19 +23,18 @@ pub async fn ws_events(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> axum::response::Response {
-    // Validate auth token from query param (browsers can't set headers for WS).
-    let is_authenticated = params
-        .get("auth")
-        .map(|token| {
-            token == &state.api_token
-                || crate::api::auth::validate_jwt(token, &state.jwt_secret).is_ok()
-        })
-        .unwrap_or(false);
+    // Consume the one-time ticket before upgrading.
+    let is_authenticated = match params.get("ticket") {
+        Some(ticket) => state.ws_tickets.consume(ticket).await,
+        None => false,
+    };
 
     if !is_authenticated {
         return axum::response::Response::builder()
             .status(axum::http::StatusCode::UNAUTHORIZED)
-            .body(axum::body::Body::from("Missing or invalid auth token"))
+            .body(axum::body::Body::from(
+                "Missing or invalid WebSocket ticket",
+            ))
             .expect("response build is infallible");
     }
 
@@ -95,11 +93,27 @@ async fn handle_ws(
 
 #[cfg(test)]
 mod tests {
-    // WebSocket handlers are hard to unit test directly.
-    // Integration tests will cover the WS upgrade + event flow.
-    // Here we test that the handler function exists and compiles.
+    // Exercise the authentication handshake against a real loopback server;
+    // the extractor requires Hyper's live connection-upgrade extension.
     use super::*;
     use crate::api::server::AppState;
+    use axum::http::StatusCode;
+
+    async fn spawn_ws_app(state: AppState) -> std::net::SocketAddr {
+        let app = crate::api::server::build_router(state, None, None);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("listener must have an address");
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server must run");
+        });
+        addr
+    }
 
     #[test]
     fn test_ws_handler_compiles() {
@@ -124,5 +138,48 @@ mod tests {
         // Releasing one permit makes room again.
         drop(permits.pop());
         assert_eq!(sem.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_ws_upgrade_consumes_ticket_once() {
+        let bus = EventBus::new(8);
+        let state = AppState::new("static-token".into(), bus);
+        let ticket = state.ws_tickets.issue().await;
+        let addr = spawn_ws_app(state).await;
+        let url = format!("ws://{addr}/ws/events?ticket={ticket}");
+
+        let (mut socket, response) = tokio_tungstenite::connect_async(&url)
+            .await
+            .expect("valid ticket must upgrade");
+        assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+        socket.close(None).await.expect("socket must close");
+
+        let replay = tokio_tungstenite::connect_async(&url)
+            .await
+            .expect_err("consumed ticket must be rejected");
+        match replay {
+            tokio_tungstenite::tungstenite::Error::Http(response) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            }
+            other => panic!("expected HTTP rejection, got {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ws_upgrade_rejects_long_lived_token_query() {
+        let bus = EventBus::new(8);
+        let state = AppState::new("static-token".into(), bus);
+        let addr = spawn_ws_app(state).await;
+
+        let result =
+            tokio_tungstenite::connect_async(format!("ws://{addr}/ws/events?auth=static-token"))
+                .await
+                .expect_err("long-lived token query must be rejected");
+        match result {
+            tokio_tungstenite::tungstenite::Error::Http(response) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            }
+            other => panic!("expected HTTP rejection, got {other}"),
+        }
     }
 }

--- a/src/api/routes/ws.rs
+++ b/src/api/routes/ws.rs
@@ -144,7 +144,7 @@ mod tests {
     async fn test_ws_upgrade_consumes_ticket_once() {
         let bus = EventBus::new(8);
         let state = AppState::new("static-token".into(), bus);
-        let ticket = state.ws_tickets.issue().await;
+        let ticket = state.ws_tickets.issue().await.expect("store has capacity");
         let addr = spawn_ws_app(state).await;
         let url = format!("ws://{addr}/ws/events?ticket={ticket}");
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -212,6 +212,7 @@ pub async fn start_server(
     state: AppState,
     static_dir: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    state.ws_tickets.start_cleanup();
     let cors_origin = format!("http://{}:{}", config.bind, config.port);
     let app = build_router(state, static_dir, Some(cors_origin));
     let addr = format!("{}:{}", config.bind, config.api_port);

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -35,6 +35,8 @@ pub struct AppState {
     /// holds it for the lifetime of the connection; once the semaphore is
     /// exhausted the handler returns HTTP 503.
     pub ws_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Short-lived, single-use tickets accepted by the WebSocket endpoint.
+    pub ws_tickets: Arc<crate::api::auth::WsTicketStore>,
     // ── Real data stores (all optional — set when wired from gateway/CLI) ───
     /// Session manager for reading and deleting conversation sessions.
     pub session_manager: Option<Arc<crate::session::SessionManager>>,
@@ -64,6 +66,7 @@ impl AppState {
             password_hash: None,
             jwt_secret: uuid::Uuid::new_v4().to_string(),
             ws_semaphore: Arc::new(tokio::sync::Semaphore::new(Self::MAX_WS_CONNECTIONS)),
+            ws_tickets: Arc::new(crate::api::auth::WsTicketStore::default()),
             session_manager: None,
             task_store: None,
             health_registry: None,
@@ -119,6 +122,10 @@ pub fn build_router(
     let api = Router::new()
         // Auth
         .route("/api/auth/login", post(super::routes::auth::login))
+        .route(
+            "/api/auth/ws-ticket",
+            post(super::routes::auth::issue_ws_ticket),
+        )
         // CSRF bootstrap — public, no auth required
         .route("/api/csrf-token", get(csrf_token_handler))
         // Health & metrics

--- a/src/cli/panel.rs
+++ b/src/cli/panel.rs
@@ -218,7 +218,7 @@ async fn cmd_start(
             panel_config.bind, panel_config.port
         );
     }
-    println!("API token: {api_token}");
+    println!("API token file: {}", tp.display());
     println!("Press Ctrl+C to stop.");
 
     start_server(&panel_config, state, static_dir)
@@ -368,10 +368,10 @@ async fn cmd_install(download: bool, rebuild: bool) -> Result<()> {
     // 7. Ensure an API token exists (generate + persist if missing)
     // ------------------------------------------------------------------
     let tp = token_path();
-    let token = ensure_api_token(&tp).await?;
+    ensure_api_token(&tp).await?;
 
     println!("\n  Panel installed successfully!");
-    println!("  API token: {token}");
+    println!("  API token file: {}", tp.display());
     println!("\n  Start with: zeptoclaw panel");
 
     Ok(())


### PR DESCRIPTION
Panel WebSocket connections previously placed the long-lived API token or JWT in `?auth=`, exposing credentials to access logs and browser history. The panel now obtains a 30-second single-use ticket through an authenticated, CSRF-protected endpoint and consumes it during the WebSocket upgrade; replay and the former bearer-token query are rejected. Pending tickets are capped at 64, swept after expiry, and return HTTP 429 with retry guidance at capacity.

This also centralizes static bearer validation on `subtle` constant-time comparison and changes panel start/install output to show the protected token-file path without printing the secret.

Validation:
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --features panel --lib -- -D warnings`
- `cargo nextest run --lib` (3531 passed, 6 skipped)
- `cargo test --doc` (128 passed, 27 ignored)
- focused panel API/auth/WebSocket tests
- `pnpm build`
- `pnpm exec eslint src/hooks/useWebSocket.ts`

The frontend uses effect-local cancellation so delayed ticket responses cannot create duplicate sockets after React effect cleanup.

Closes #653
Closes #655
Closes #656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * WebSocket connections now use short-lived, single-use authentication tickets.
  * Reusing an expired or previously consumed ticket is rejected.
  * Static bearer tokens are compared more securely.
  * WebSocket ticket requests are protected by authentication and CSRF checks.

* **User Experience**
  * Startup and installation output now displays the API token file location instead of the token itself.
  * Ticket requests receive a clear temporary-unavailable response when capacity is reached.

* **Documentation**
  * Updated architecture documentation to reflect panel API, WebSocket ticket authentication, and OpenAI-compatible routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->