### PR TITLE
fix(ci): allow rustsec audit check reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0


### PR DESCRIPTION
The security audit finds no vulnerabilities on main, but `rustsec/audit-check` cannot publish its result because the job token lacks check-run access. Grant the audit job only `contents: read` and `checks: write`, allowing the action to report its result while keeping permissions scoped to that job.

Validation:
- workflow YAML parse
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo nextest run --lib` (3531 passed, 6 skipped)
- `cargo test --doc` (128 passed, 27 ignored)

Closes #676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated audit checks with the permissions needed to read repository contents and write check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->